### PR TITLE
illustration of handling packages in prior JSON

### DIFF
--- a/test_autolens/config/priors/pixelization.json
+++ b/test_autolens/config/priors/pixelization.json
@@ -1,5 +1,33 @@
 {
-    "Rectangular": {
+    "rectangular.Rectangular": {
+        "shape_0": {
+            "type": "Uniform",
+            "lower_limit": 32.1,
+            "upper_limit": 45.0,
+            "width_modifier": {
+                "type": "Absolute",
+                "value": 8.0
+            },
+            "gaussian_limits": {
+                "lower": 3.0,
+                "upper": "inf"
+            }
+        },
+        "shape_1": {
+            "type": "Uniform",
+            "lower_limit": 20.0,
+            "upper_limit": 45.0,
+            "width_modifier": {
+                "type": "Absolute",
+                "value": 8.0
+            },
+            "gaussian_limits": {
+                "lower": 3.0,
+                "upper": "inf"
+            }
+        }
+    },
+    "voronoi.VoronoiMagnification": {
         "shape_0": {
             "type": "Uniform",
             "lower_limit": 20.0,
@@ -27,35 +55,7 @@
             }
         }
     },
-    "VoronoiMagnification": {
-        "shape_0": {
-            "type": "Uniform",
-            "lower_limit": 20.0,
-            "upper_limit": 45.0,
-            "width_modifier": {
-                "type": "Absolute",
-                "value": 8.0
-            },
-            "gaussian_limits": {
-                "lower": 3.0,
-                "upper": "inf"
-            }
-        },
-        "shape_1": {
-            "type": "Uniform",
-            "lower_limit": 20.0,
-            "upper_limit": 45.0,
-            "width_modifier": {
-                "type": "Absolute",
-                "value": 8.0
-            },
-            "gaussian_limits": {
-                "lower": 3.0,
-                "upper": "inf"
-            }
-        }
-    },
-    "VoronoiBrightnessImage": {
+    "voronoi.VoronoiBrightnessImage": {
         "pixels": {
             "type": "Uniform",
             "lower_limit": 50.0,

--- a/test_autolens/imaging/test_regression.py
+++ b/test_autolens/imaging/test_regression.py
@@ -1,0 +1,8 @@
+import autoarray as aa
+import autofit as af
+
+
+def test_pixelization_config():
+    model = af.Model(aa.pix.Rectangular)
+    assert model.shape[0].lower_limit == 32.1
+    model.instance_from_prior_medians()


### PR DESCRIPTION
Illustrates how packages should be handled.

Note that I changed the prior JSON filename to pixelization.json so it corresponded to the package name rather than to the hacky module.
