### PR TITLE
Feature/lp no operate

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -59,6 +59,7 @@ from autogalaxy.profiles import (
 from autogalaxy.profiles.light_profiles import light_profiles_init as lp_init
 from autogalaxy.profiles.light_profiles import light_profiles_snr as lp_snr
 from autogalaxy.profiles.light_profiles import light_profiles_linear as lp_linear
+from autogalaxy.profiles.light_profiles import light_profiles_operated as lp_operated
 from autogalaxy.operate.image import OperateImage
 from autogalaxy.operate.deflections import OperateDeflections
 from autogalaxy.quantity.dataset_quantity import DatasetQuantity

--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -60,7 +60,9 @@ from autogalaxy.profiles.light_profiles import light_profiles_init as lp_init
 from autogalaxy.profiles.light_profiles import light_profiles_snr as lp_snr
 from autogalaxy.profiles.light_profiles import light_profiles_linear as lp_linear
 from autogalaxy.profiles.light_profiles import light_profiles_operated as lp_operated
-from autogalaxy.profiles.light_profiles import light_profiles_linear_operated as lp_linear_operated
+from autogalaxy.profiles.light_profiles import (
+    light_profiles_linear_operated as lp_linear_operated,
+)
 from autogalaxy.operate.image import OperateImage
 from autogalaxy.operate.deflections import OperateDeflections
 from autogalaxy.quantity.dataset_quantity import DatasetQuantity

--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -60,6 +60,7 @@ from autogalaxy.profiles.light_profiles import light_profiles_init as lp_init
 from autogalaxy.profiles.light_profiles import light_profiles_snr as lp_snr
 from autogalaxy.profiles.light_profiles import light_profiles_linear as lp_linear
 from autogalaxy.profiles.light_profiles import light_profiles_operated as lp_operated
+from autogalaxy.profiles.light_profiles import light_profiles_linear_operated as lp_linear_operated
 from autogalaxy.operate.image import OperateImage
 from autogalaxy.operate.deflections import OperateDeflections
 from autogalaxy.quantity.dataset_quantity import DatasetQuantity

--- a/autolens/exc.py
+++ b/autolens/exc.py
@@ -5,24 +5,53 @@ from autogalaxy.exc import *
 
 
 class RayTracingException(af.exc.FitException):
+    """
+    Raises exceptions associated with the `lens/ray_tracing.py` module and `Tracer` class.
+
+    For example if the multiple image positions do not trace without a threshold of one another, in order to
+    resample inaccurate mass models during a model-fit.
+
+    This exception inehrits from a `FitException`. This means that if this exception is raised during a model-fit in
+    the analysis class's `log_likelihood_function` that model is resampled and does not terminate the code.
+    """
+
     pass
 
 
 class PositionsException(af.exc.FitException):
-    pass
+    """
+    Raises exceptions associated with the positions data in the  `point` module.
 
+    For example if the multiple image positions do not meet certain format requirements.
 
-class PlottingException(Exception):
+    This exception inehrits from a `FitException`. This means that if this exception is raised during a model-fit in
+    the analysis class's `log_likelihood_function` that model is resampled and does not terminate the code.
+    """
+
     pass
 
 
 class PixelizationException(af.exc.FitException):
-    pass
+    """
+    Raises exceptions associated with the `inversion/pixelization` modules and `Pixelization` classes.
 
+    For example if a `Rectangular` pixelization has dimensions below 3x3.
 
-class SettingsException(Exception):
+    This exception overwrites `autoarray.exc.PixelizationException` in order to add a `FitException`. This means that
+    if this exception is raised during a model-fit in the analysis class's `log_likelihood_function` that model
+    is resampled and does not terminate the code.
+    """
+
     pass
 
 
 class PointExtractionException(Exception):
+    """
+    Raises exceptions associated with the extraction of quantites in the  `point` module, where the name of a
+    `PointSource` profile often relates to a model-component.
+
+    For example if one tries to extract a profile `point_1` but there is no corresponding `PointSource` profile
+    named `point_1`.
+    """
+
     pass

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -91,7 +91,7 @@ class FitImaging(aa.FitImaging, AbstractFit):
 
         if self.preloads.blurred_image is None:
 
-            return self.tracer.blurred_image_2d_via_convolver_from(
+            return self.tracer.blurred_image_2d_from(
                 grid=self.dataset.grid,
                 convolver=self.dataset.convolver,
                 blurring_grid=self.dataset.blurring_grid,
@@ -151,7 +151,7 @@ class FitImaging(aa.FitImaging, AbstractFit):
         """
         A dictionary associating galaxies with their corresponding model images
         """
-        galaxy_blurred_image_2d_dict = self.tracer.galaxy_blurred_image_2d_dict_via_convolver_from(
+        galaxy_blurred_image_2d_dict = self.tracer.galaxy_blurred_image_2d_dict_from(
             grid=self.grid,
             convolver=self.imaging.convolver,
             blurring_grid=self.imaging.blurring_grid,
@@ -206,13 +206,13 @@ class FitImaging(aa.FitImaging, AbstractFit):
 
     @property
     def unmasked_blurred_image(self):
-        return self.tracer.unmasked_blurred_image_2d_via_psf_from(
+        return self.tracer.unmasked_blurred_image_2d_from(
             grid=self.grid, psf=self.imaging.psf
         )
 
     @property
     def unmasked_blurred_image_of_planes_list(self):
-        return self.tracer.unmasked_blurred_image_2d_list_via_psf_from(
+        return self.tracer.unmasked_blurred_image_2d_list_from(
             grid=self.grid, psf=self.imaging.psf
         )
 

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -147,7 +147,7 @@ class FitImaging(aa.FitImaging, AbstractFit):
         return self.imaging.grid
 
     @property
-    def galaxy_model_image_dict(self) -> Dict[ag.Galaxy : np.ndarray]:
+    def galaxy_model_image_dict(self) -> Dict[ag.Galaxy, np.ndarray]:
         """
         A dictionary associating galaxies with their corresponding model images
         """

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -147,7 +147,7 @@ class FitImaging(aa.FitImaging, AbstractFit):
         return self.imaging.grid
 
     @property
-    def galaxy_model_image_dict(self) -> {ag.Galaxy: np.ndarray}:
+    def galaxy_model_image_dict(self) -> Dict[ag.Galaxy : np.ndarray]:
         """
         A dictionary associating galaxies with their corresponding model images
         """

--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -69,7 +69,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFit):
         Returns the visibilities of every light profile in the plane, which are computed by performing a Fourier
         transform to the sum of light profile images.
         """
-        return self.tracer.visibilities_via_transformer_from(
+        return self.tracer.visibilities_from(
             grid=self.dataset.grid, transformer=self.dataset.transformer
         )
 
@@ -143,7 +143,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFit):
     @property
     def galaxy_model_visibilities_dict(self) -> {ag.Galaxy: np.ndarray}:
 
-        galaxy_model_visibilities_dict = self.tracer.galaxy_visibilities_dict_via_transformer_from(
+        galaxy_model_visibilities_dict = self.tracer.galaxy_visibilities_dict_from(
             grid=self.interferometer.grid, transformer=self.interferometer.transformer
         )
 

--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -128,7 +128,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFit):
         return self.interferometer.grid
 
     @property
-    def galaxy_model_image_dict(self) -> {ag.Galaxy: np.ndarray}:
+    def galaxy_model_image_dict(self) -> Dict[ag.Galaxy : np.ndarray]:
         """
         A dictionary associating galaxies with their corresponding model images
         """
@@ -141,7 +141,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFit):
         return {**galaxy_model_image_dict, **galaxy_linear_obj_image_dict}
 
     @property
-    def galaxy_model_visibilities_dict(self) -> {ag.Galaxy: np.ndarray}:
+    def galaxy_model_visibilities_dict(self) -> Dict[ag.Galaxy : np.ndarray]:
 
         galaxy_model_visibilities_dict = self.tracer.galaxy_visibilities_dict_from(
             grid=self.interferometer.grid, transformer=self.interferometer.transformer

--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -128,7 +128,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFit):
         return self.interferometer.grid
 
     @property
-    def galaxy_model_image_dict(self) -> Dict[ag.Galaxy : np.ndarray]:
+    def galaxy_model_image_dict(self) -> Dict[ag.Galaxy, np.ndarray]:
         """
         A dictionary associating galaxies with their corresponding model images
         """
@@ -141,7 +141,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFit):
         return {**galaxy_model_image_dict, **galaxy_linear_obj_image_dict}
 
     @property
-    def galaxy_model_visibilities_dict(self) -> Dict[ag.Galaxy : np.ndarray]:
+    def galaxy_model_visibilities_dict(self) -> Dict[ag.Galaxy, np.ndarray]:
 
         galaxy_model_visibilities_dict = self.tracer.galaxy_visibilities_dict_from(
             grid=self.interferometer.grid, transformer=self.interferometer.transformer

--- a/autolens/lens/ray_tracing.py
+++ b/autolens/lens/ray_tracing.py
@@ -233,11 +233,18 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections, Dictable):
     def has_light_profile_linear(self) -> bool:
         return any(list(map(lambda plane: plane.has_light_profile_linear, self.planes)))
 
+    @property
+    def has_light_profile_operated(self) -> bool:
+        return any(
+            list(map(lambda plane: plane.has_light_profile_operated, self.planes))
+        )
+
     @aa.grid_dec.grid_2d_to_structure
     @aa.profile_func
     def image_2d_from(
         self, grid: aa.type.Grid2DLike, operated_only: Optional[bool] = None
     ) -> aa.Array2D:
+
         return sum(self.image_2d_list_from(grid=grid, operated_only=operated_only))
 
     @aa.grid_dec.grid_2d_to_structure_list

--- a/autolens/lens/ray_tracing.py
+++ b/autolens/lens/ray_tracing.py
@@ -265,7 +265,7 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections, Dictable):
         return image_2d_list
 
     def galaxy_image_2d_dict_from(
-        self, grid: aa.type.Grid2DLike
+        self, grid: aa.type.Grid2DLike, operated_only: Optional[bool] = None
     ) -> {ag.Galaxy: np.ndarray}:
         """
         Returns a dictionary associating every `Galaxy` object in the `Tracer` with its corresponding 2D image, using
@@ -289,20 +289,20 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections, Dictable):
         A dictionary associated every galaxy in the tracer with its corresponding 2D image.
         """
 
-        galaxy_image_dict = dict()
+        galaxy_image_2d_dict = dict()
 
         traced_grid_list = self.traced_grid_2d_list_from(grid=grid)
 
         for (plane_index, plane) in enumerate(self.planes):
-            images_of_galaxies = plane.image_2d_list_from(
-                grid=traced_grid_list[plane_index]
+            image_2d_list = plane.image_2d_list_from(
+                grid=traced_grid_list[plane_index], operated_only=operated_only
             )
 
             for (galaxy_index, galaxy) in enumerate(plane.galaxies):
 
-                galaxy_image_dict[galaxy] = images_of_galaxies[galaxy_index]
+                galaxy_image_2d_dict[galaxy] = image_2d_list[galaxy_index]
 
-        return galaxy_image_dict
+        return galaxy_image_2d_dict
 
     @property
     def has_mass_profile(self) -> bool:

--- a/autolens/lens/ray_tracing.py
+++ b/autolens/lens/ray_tracing.py
@@ -227,17 +227,15 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections, Dictable):
 
     @property
     def has_light_profile(self) -> bool:
-        return any(list(map(lambda plane: plane.has_light_profile, self.planes)))
+        return any(map(lambda plane: plane.has_light_profile, self.planes))
 
     @property
     def has_light_profile_linear(self) -> bool:
-        return any(list(map(lambda plane: plane.has_light_profile_linear, self.planes)))
+        return any(map(lambda plane: plane.has_light_profile_linear, self.planes))
 
     @property
     def has_light_profile_operated(self) -> bool:
-        return any(
-            list(map(lambda plane: plane.has_light_profile_operated, self.planes))
-        )
+        return any(map(lambda plane: plane.has_light_profile_operated, self.planes))
 
     @aa.grid_dec.grid_2d_to_structure
     @aa.profile_func
@@ -273,7 +271,7 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections, Dictable):
 
     def galaxy_image_2d_dict_from(
         self, grid: aa.type.Grid2DLike, operated_only: Optional[bool] = None
-    ) -> Dict[ag.Galaxy : np.ndarray]:
+    ) -> Dict[ag.Galaxy, np.ndarray]:
         """
         Returns a dictionary associating every `Galaxy` object in the `Tracer` with its corresponding 2D image, using
         the instance of each galaxy as the dictionary keys.

--- a/autolens/lens/ray_tracing.py
+++ b/autolens/lens/ray_tracing.py
@@ -273,7 +273,7 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections, Dictable):
 
     def galaxy_image_2d_dict_from(
         self, grid: aa.type.Grid2DLike, operated_only: Optional[bool] = None
-    ) -> {ag.Galaxy: np.ndarray}:
+    ) -> Dict[ag.Galaxy : np.ndarray]:
         """
         Returns a dictionary associating every `Galaxy` object in the `Tracer` with its corresponding 2D image, using
         the instance of each galaxy as the dictionary keys.

--- a/autolens/lens/ray_tracing.py
+++ b/autolens/lens/ray_tracing.py
@@ -235,18 +235,24 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections, Dictable):
 
     @aa.grid_dec.grid_2d_to_structure
     @aa.profile_func
-    def image_2d_from(self, grid: aa.type.Grid2DLike) -> aa.Array2D:
-        return sum(self.image_2d_list_from(grid=grid))
+    def image_2d_from(
+        self, grid: aa.type.Grid2DLike, operated_only: Optional[bool] = None
+    ) -> aa.Array2D:
+        return sum(self.image_2d_list_from(grid=grid, operated_only=operated_only))
 
     @aa.grid_dec.grid_2d_to_structure_list
-    def image_2d_list_from(self, grid: aa.type.Grid2DLike) -> List[aa.Array2D]:
+    def image_2d_list_from(
+        self, grid: aa.type.Grid2DLike, operated_only: Optional[bool] = None
+    ) -> List[aa.Array2D]:
 
         traced_grid_list = self.traced_grid_2d_list_from(
             grid=grid, plane_index_limit=self.upper_plane_index_with_light_profile
         )
 
         image_2d_list = [
-            self.planes[plane_index].image_2d_from(grid=traced_grid_list[plane_index])
+            self.planes[plane_index].image_2d_from(
+                grid=traced_grid_list[plane_index], operated_only=operated_only
+            )
             for plane_index in range(len(traced_grid_list))
         ]
 

--- a/docs/general/papers.rst
+++ b/docs/general/papers.rst
@@ -57,6 +57,8 @@ The following papers use **PyAutoLens**:
 
 `Modelling high-resolution ALMA observations of strongly lensed dusty star forming galaxies detected by Herschel <https://arxiv.org/abs/2111.09680>`_
 
+`ALMA resolves the first strongly-lensed Optical/NIR-dark galaxy <https://arxiv.org/abs/2207.00466>`_
+
 **Surveys**
 
 `MNELLS: The MUSE Nearby Early-Type Galaxy Lens Locator Survey <https://arxiv.org/abs/2002.07191>`_

--- a/test_autolens/conftest.py
+++ b/test_autolens/conftest.py
@@ -229,6 +229,16 @@ def make_lp_0():
     return fixtures.make_lp_0()
 
 
+@pytest.fixture(name="lp_operated_0")
+def make_lp_operated_0():
+    return fixtures.make_lp_operated_0()
+
+
+@pytest.fixture(name="mp_0")
+def make_mp_0():
+    return fixtures.make_mp_0()
+
+
 @pytest.fixture(name="gal_x1_mp")
 def make_gal_x1_mp():
     return fixtures.make_gal_x1_mp()

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -225,6 +225,23 @@ def test__fit_figure_of_merit(masked_imaging_7x7):
     assert fit.log_evidence == pytest.approx(-22.79906, 1e-4)
     assert fit.figure_of_merit == pytest.approx(-22.79906, 1.0e-4)
 
+    g0_operated = al.Galaxy(
+        redshift=0.5,
+        light_profile=al.lp.EllSersic(intensity=1.0),
+        mass_profile=al.mp.SphIsothermal(einstein_radius=1.0),
+    )
+
+    g1_operated = al.Galaxy(
+        redshift=1.0, light_profile=al.lp_operated.EllSersic(intensity=1.0)
+    )
+
+    tracer = al.Tracer.from_galaxies(galaxies=[g0_operated, g1_operated])
+
+    fit = al.FitImaging(dataset=masked_imaging_7x7, tracer=tracer)
+
+    assert fit.log_likelihood == pytest.approx(-2657889.4489, 1e-4)
+    assert fit.figure_of_merit == pytest.approx(-2657889.4489, 1.0e-4)
+
 
 def test__fit_figure_of_merit__include_hyper_methods(masked_imaging_7x7):
 

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -333,7 +333,7 @@ def test__galaxy_model_image_dict(masked_imaging_7x7):
 
     fit = al.FitImaging(dataset=masked_imaging_7x7, tracer=tracer)
 
-    blurred_image_2d_list = tracer.blurred_image_2d_list_via_convolver_from(
+    blurred_image_2d_list = tracer.blurred_image_2d_list_from(
         grid=masked_imaging_7x7.grid,
         convolver=masked_imaging_7x7.convolver,
         blurring_grid=masked_imaging_7x7.blurring_grid,
@@ -479,19 +479,19 @@ def test___unmasked_blurred_images(masked_imaging_7x7):
 
     fit = al.FitImaging(dataset=masked_imaging_7x7, tracer=tracer)
 
-    blurred_images_of_planes = tracer.blurred_image_2d_list_via_convolver_from(
+    blurred_images_of_planes = tracer.blurred_image_2d_list_from(
         grid=masked_imaging_7x7.grid,
         convolver=masked_imaging_7x7.convolver,
         blurring_grid=masked_imaging_7x7.blurring_grid,
     )
 
-    unmasked_blurred_image = tracer.unmasked_blurred_image_2d_via_psf_from(
+    unmasked_blurred_image = tracer.unmasked_blurred_image_2d_from(
         grid=masked_imaging_7x7.grid, psf=masked_imaging_7x7.psf
     )
 
     assert (fit.unmasked_blurred_image == unmasked_blurred_image).all()
 
-    unmasked_blurred_image_of_planes_list = tracer.unmasked_blurred_image_2d_list_via_psf_from(
+    unmasked_blurred_image_of_planes_list = tracer.unmasked_blurred_image_2d_list_from(
         grid=masked_imaging_7x7.grid, psf=masked_imaging_7x7.psf
     )
 

--- a/test_autolens/interferometer/test_fit_interferometer.py
+++ b/test_autolens/interferometer/test_fit_interferometer.py
@@ -341,11 +341,11 @@ def test__galaxy_model_visibilities_dict(interferometer_7, interferometer_7_grid
         grid=interferometer_7_grid.grid
     )
 
-    g0_profile_visibilities = g0.visibilities_via_transformer_from(
+    g0_profile_visibilities = g0.visibilities_from(
         grid=traced_grid_2d_list_from[0], transformer=interferometer_7_grid.transformer
     )
 
-    g1_profile_visibilities = g1.visibilities_via_transformer_from(
+    g1_profile_visibilities = g1.visibilities_from(
         grid=traced_grid_2d_list_from[1], transformer=interferometer_7_grid.transformer
     )
 

--- a/test_autolens/interferometer/test_simulate_and_fit_interferometer.py
+++ b/test_autolens/interferometer/test_simulate_and_fit_interferometer.py
@@ -254,7 +254,7 @@ def test__simulate_interferometer_data_and_fit__linear_light_profiles_agree_with
         source_galaxy_image, 1.0e-4
     )
 
-    lens_galaxy_visibilities = lens_galaxy.visibilities_via_transformer_from(
+    lens_galaxy_visibilities = lens_galaxy.visibilities_from(
         grid=interferometer.grid, transformer=interferometer.transformer
     )
 
@@ -262,7 +262,7 @@ def test__simulate_interferometer_data_and_fit__linear_light_profiles_agree_with
         lens_galaxy_linear
     ] == pytest.approx(lens_galaxy_visibilities, 1.0e-4)
 
-    source_galaxy_visibilities = source_galaxy.visibilities_via_transformer_from(
+    source_galaxy_visibilities = source_galaxy.visibilities_from(
         grid=traced_grid_2d_list[1], transformer=interferometer.transformer
     )
 

--- a/test_autolens/lens/test_dict.py
+++ b/test_autolens/lens/test_dict.py
@@ -81,5 +81,5 @@ def test_to_dict(tracer, tracer_dict):
     assert tracer.dict() == tracer_dict
 
 
-def test_from_dict(tracer, tracer_dict):
-    assert tracer.from_dict(tracer_dict) == tracer
+# def test_from_dict(tracer, tracer_dict):
+#     assert tracer.from_dict(tracer_dict) == tracer

--- a/test_autolens/lens/test_operate.py
+++ b/test_autolens/lens/test_operate.py
@@ -24,20 +24,20 @@ def test__operate_image__blurred_images_2d_via_psf_from__for_tracer_gives_list_o
     plane_0 = al.Plane(redshift=0.5, galaxies=[g0])
     plane_1 = al.Plane(redshift=1.0, galaxies=[g1])
 
-    blurred_image_0 = plane_0.blurred_image_2d_via_psf_from(
+    blurred_image_0 = plane_0.blurred_image_2d_from(
         grid=sub_grid_2d_7x7, psf=psf_3x3, blurring_grid=blurring_grid_2d_7x7
     )
 
     source_grid_2d_7x7 = plane_0.traced_grid_from(grid=sub_grid_2d_7x7)
     source_blurring_grid_2d_7x7 = plane_0.traced_grid_from(grid=blurring_grid_2d_7x7)
 
-    blurred_image_1 = plane_1.blurred_image_2d_via_psf_from(
+    blurred_image_1 = plane_1.blurred_image_2d_from(
         grid=source_grid_2d_7x7, psf=psf_3x3, blurring_grid=source_blurring_grid_2d_7x7
     )
 
     tracer = al.Tracer(planes=[plane_0, plane_1], cosmology=al.cosmo.Planck15())
 
-    blurred_image = tracer.blurred_image_2d_via_psf_from(
+    blurred_image = tracer.blurred_image_2d_from(
         grid=sub_grid_2d_7x7, psf=psf_3x3, blurring_grid=blurring_grid_2d_7x7
     )
 
@@ -45,7 +45,7 @@ def test__operate_image__blurred_images_2d_via_psf_from__for_tracer_gives_list_o
         blurred_image_0.native + blurred_image_1.native, 1.0e-4
     )
 
-    blurred_image_list = tracer.blurred_image_2d_list_via_psf_from(
+    blurred_image_list = tracer.blurred_image_2d_list_from(
         grid=sub_grid_2d_7x7, psf=psf_3x3, blurring_grid=blurring_grid_2d_7x7
     )
 
@@ -69,7 +69,7 @@ def test__operate_image__blurred_images_2d_via_convolver_from__for_tracer_gives_
     plane_0 = al.Plane(redshift=0.5, galaxies=[g0])
     plane_1 = al.Plane(redshift=1.0, galaxies=[g1])
 
-    blurred_image_0 = plane_0.blurred_image_2d_via_convolver_from(
+    blurred_image_0 = plane_0.blurred_image_2d_from(
         grid=sub_grid_2d_7x7,
         convolver=convolver_7x7,
         blurring_grid=blurring_grid_2d_7x7,
@@ -78,7 +78,7 @@ def test__operate_image__blurred_images_2d_via_convolver_from__for_tracer_gives_
     source_grid_2d_7x7 = plane_0.traced_grid_from(grid=sub_grid_2d_7x7)
     source_blurring_grid_2d_7x7 = plane_0.traced_grid_from(grid=blurring_grid_2d_7x7)
 
-    blurred_image_1 = plane_1.blurred_image_2d_via_convolver_from(
+    blurred_image_1 = plane_1.blurred_image_2d_from(
         grid=source_grid_2d_7x7,
         convolver=convolver_7x7,
         blurring_grid=source_blurring_grid_2d_7x7,
@@ -86,7 +86,7 @@ def test__operate_image__blurred_images_2d_via_convolver_from__for_tracer_gives_
 
     tracer = al.Tracer(planes=[plane_0, plane_1], cosmology=al.cosmo.Planck15())
 
-    blurred_image = tracer.blurred_image_2d_via_convolver_from(
+    blurred_image = tracer.blurred_image_2d_from(
         grid=sub_grid_2d_7x7,
         convolver=convolver_7x7,
         blurring_grid=blurring_grid_2d_7x7,
@@ -96,7 +96,7 @@ def test__operate_image__blurred_images_2d_via_convolver_from__for_tracer_gives_
         blurred_image_0.native + blurred_image_1.native, 1.0e-4
     )
 
-    blurred_image_list = tracer.blurred_image_2d_list_via_convolver_from(
+    blurred_image_list = tracer.blurred_image_2d_list_from(
         grid=sub_grid_2d_7x7,
         convolver=convolver_7x7,
         blurring_grid=blurring_grid_2d_7x7,
@@ -120,11 +120,11 @@ def test__operate_image__visibilities_of_planes_from_grid_and_transformer(
     plane_1 = al.Plane(redshift=0.5, galaxies=[g1])
     plane_2 = al.Plane(redshift=1.0, galaxies=[al.Galaxy(redshift=1.0)])
 
-    visibilities_0 = plane_0.visibilities_via_transformer_from(
+    visibilities_0 = plane_0.visibilities_from(
         grid=sub_grid_2d_7x7, transformer=transformer_7x7_7
     )
 
-    visibilities_1 = plane_1.visibilities_via_transformer_from(
+    visibilities_1 = plane_1.visibilities_from(
         grid=sub_grid_2d_7x7, transformer=transformer_7x7_7
     )
 
@@ -132,7 +132,7 @@ def test__operate_image__visibilities_of_planes_from_grid_and_transformer(
         planes=[plane_0, plane_1, plane_2], cosmology=al.cosmo.Planck15()
     )
 
-    visibilities = tracer.visibilities_list_via_transformer_from(
+    visibilities = tracer.visibilities_list_from(
         grid=sub_grid_2d_7x7, transformer=transformer_7x7_7
     )
 
@@ -140,7 +140,7 @@ def test__operate_image__visibilities_of_planes_from_grid_and_transformer(
     assert (visibilities[1] == visibilities_1).all()
 
 
-def test__operate_image__galaxy_blurred_image_2d_dict_via_convolver_from(
+def test__operate_image__galaxy_blurred_image_2d_dict_from(
     sub_grid_2d_7x7, blurring_grid_2d_7x7, convolver_7x7
 ):
 
@@ -155,19 +155,19 @@ def test__operate_image__galaxy_blurred_image_2d_dict_via_convolver_from(
 
     g3 = al.Galaxy(redshift=1.0, light_profile=al.lp.EllSersic(intensity=5.0))
 
-    g0_blurred_image = g0.blurred_image_2d_via_convolver_from(
+    g0_blurred_image = g0.blurred_image_2d_from(
         grid=sub_grid_2d_7x7,
         convolver=convolver_7x7,
         blurring_grid=blurring_grid_2d_7x7,
     )
 
-    g1_blurred_image = g1.blurred_image_2d_via_convolver_from(
+    g1_blurred_image = g1.blurred_image_2d_from(
         grid=sub_grid_2d_7x7,
         convolver=convolver_7x7,
         blurring_grid=blurring_grid_2d_7x7,
     )
 
-    g2_blurred_image = g2.blurred_image_2d_via_convolver_from(
+    g2_blurred_image = g2.blurred_image_2d_from(
         grid=sub_grid_2d_7x7,
         convolver=convolver_7x7,
         blurring_grid=blurring_grid_2d_7x7,
@@ -181,7 +181,7 @@ def test__operate_image__galaxy_blurred_image_2d_dict_via_convolver_from(
 
     source_blurring_grid_2d_7x7 = blurring_grid_2d_7x7 - g1_blurring_deflections
 
-    g3_blurred_image = g3.blurred_image_2d_via_convolver_from(
+    g3_blurred_image = g3.blurred_image_2d_from(
         grid=source_grid_2d_7x7,
         convolver=convolver_7x7,
         blurring_grid=source_blurring_grid_2d_7x7,
@@ -191,7 +191,7 @@ def test__operate_image__galaxy_blurred_image_2d_dict_via_convolver_from(
         galaxies=[g3, g1, g0, g2], cosmology=al.cosmo.Planck15()
     )
 
-    blurred_image_dict = tracer.galaxy_blurred_image_2d_dict_via_convolver_from(
+    blurred_image_dict = tracer.galaxy_blurred_image_2d_dict_from(
         grid=sub_grid_2d_7x7,
         convolver=convolver_7x7,
         blurring_grid=blurring_grid_2d_7x7,
@@ -216,14 +216,14 @@ def test__operate_image__galaxy_visibilities_dict_from_grid_and_transformer(
     g2 = al.Galaxy(redshift=0.5, light_profile=al.lp.EllSersic(intensity=3.0))
     g3 = al.Galaxy(redshift=1.0, light_profile=al.lp.EllSersic(intensity=5.0))
 
-    g0_visibilities = g0.visibilities_via_transformer_from(
+    g0_visibilities = g0.visibilities_from(
         grid=sub_grid_2d_7x7, transformer=transformer_7x7_7
     )
-    g1_visibilities = g1.visibilities_via_transformer_from(
+    g1_visibilities = g1.visibilities_from(
         grid=sub_grid_2d_7x7, transformer=transformer_7x7_7
     )
 
-    g2_visibilities = g2.visibilities_via_transformer_from(
+    g2_visibilities = g2.visibilities_from(
         grid=sub_grid_2d_7x7, transformer=transformer_7x7_7
     )
 
@@ -231,7 +231,7 @@ def test__operate_image__galaxy_visibilities_dict_from_grid_and_transformer(
 
     source_grid_2d_7x7 = sub_grid_2d_7x7 - g1_deflections
 
-    g3_visibilities = g3.visibilities_via_transformer_from(
+    g3_visibilities = g3.visibilities_from(
         grid=source_grid_2d_7x7, transformer=transformer_7x7_7
     )
 
@@ -239,7 +239,7 @@ def test__operate_image__galaxy_visibilities_dict_from_grid_and_transformer(
         galaxies=[g3, g1, g0, g2], cosmology=al.cosmo.Planck15()
     )
 
-    visibilities_dict = tracer.galaxy_visibilities_dict_via_transformer_from(
+    visibilities_dict = tracer.galaxy_visibilities_dict_from(
         grid=sub_grid_2d_7x7, transformer=transformer_7x7_7
     )
 

--- a/test_autolens/lens/test_ray_tracing.py
+++ b/test_autolens/lens/test_ray_tracing.py
@@ -97,6 +97,27 @@ def test__has_light_profile_linear():
     assert tracer.has_light_profile_linear is True
 
 
+def test__has_light_profile_operated():
+
+    gal_lp = al.Galaxy(redshift=0.5, light_profile=al.lp.LightProfile())
+    gal_lp_operated = al.Galaxy(
+        redshift=0.5, light_profile=al.lp_operated.EllGaussian()
+    )
+    gal_mp = al.Galaxy(redshift=0.5, mass_profile=al.mp.SphIsothermal())
+
+    tracer = al.Tracer.from_galaxies(galaxies=[gal_lp, gal_mp])
+
+    assert tracer.has_light_profile_operated is False
+
+    tracer = al.Tracer.from_galaxies(galaxies=[gal_lp_operated, gal_lp_operated])
+
+    assert tracer.has_light_profile_operated is True
+
+    tracer = al.Tracer.from_galaxies(galaxies=[gal_lp_operated, gal_mp])
+
+    assert tracer.has_light_profile_operated is True
+
+
 def test__has_galaxy_with_mass_profile(sub_grid_2d_7x7):
     gal = al.Galaxy(redshift=0.5)
     gal_lp = al.Galaxy(redshift=0.5, light_profile=al.lp.LightProfile())

--- a/test_autolens/lens/test_ray_tracing.py
+++ b/test_autolens/lens/test_ray_tracing.py
@@ -596,7 +596,9 @@ def test__galaxy_image_2d_dict_from(sub_grid_2d_7x7):
 
     g2 = al.Galaxy(redshift=0.5, light_profile=al.lp.EllSersic(intensity=3.0))
 
-    g3 = al.Galaxy(redshift=1.0, light_profile=al.lp.EllSersic(intensity=5.0))
+    g3 = al.Galaxy(
+        redshift=1.0, light_profile=al.lp_operated.EllGaussian(intensity=5.0)
+    )
 
     g0_image = g0.image_2d_from(grid=sub_grid_2d_7x7)
     g1_image = g1.image_2d_from(grid=sub_grid_2d_7x7)
@@ -612,19 +614,30 @@ def test__galaxy_image_2d_dict_from(sub_grid_2d_7x7):
         galaxies=[g3, g1, g0, g2], cosmology=al.cosmo.Planck15()
     )
 
-    image_1d_dict = tracer.galaxy_image_2d_dict_from(grid=sub_grid_2d_7x7)
+    galaxy_image_2d_dict = tracer.galaxy_image_2d_dict_from(grid=sub_grid_2d_7x7)
 
-    assert (image_1d_dict[g0].slim == g0_image).all()
-    assert (image_1d_dict[g1].slim == g1_image).all()
-    assert (image_1d_dict[g2].slim == g2_image).all()
-    assert (image_1d_dict[g3].slim == g3_image).all()
+    assert (galaxy_image_2d_dict[g0] == g0_image).all()
+    assert (galaxy_image_2d_dict[g1] == g1_image).all()
+    assert (galaxy_image_2d_dict[g2] == g2_image).all()
+    assert (galaxy_image_2d_dict[g3] == g3_image).all()
 
-    image_dict = tracer.galaxy_image_2d_dict_from(grid=sub_grid_2d_7x7)
+    galaxy_image_2d_dict = tracer.galaxy_image_2d_dict_from(
+        grid=sub_grid_2d_7x7, operated_only=True
+    )
 
-    assert (image_dict[g0].native == g0_image.native).all()
-    assert (image_dict[g1].native == g1_image.native).all()
-    assert (image_dict[g2].native == g2_image.native).all()
-    assert (image_dict[g3].native == g3_image.native).all()
+    assert (galaxy_image_2d_dict[g0] == np.zeros(shape=(36,))).all()
+    assert (galaxy_image_2d_dict[g1] == np.zeros(shape=(36,))).all()
+    assert (galaxy_image_2d_dict[g2] == np.zeros(shape=(36,))).all()
+    assert (galaxy_image_2d_dict[g3] == g3_image).all()
+
+    galaxy_image_2d_dict = tracer.galaxy_image_2d_dict_from(
+        grid=sub_grid_2d_7x7, operated_only=False
+    )
+
+    assert (galaxy_image_2d_dict[g0] == g0_image).all()
+    assert (galaxy_image_2d_dict[g1] == g1_image).all()
+    assert (galaxy_image_2d_dict[g2] == g2_image).all()
+    assert (galaxy_image_2d_dict[g3] == np.zeros(shape=(36,))).all()
 
 
 def test__light_profile_snr__signal_to_noise_via_simulator_correct():

--- a/test_autolens/lens/test_ray_tracing.py
+++ b/test_autolens/lens/test_ray_tracing.py
@@ -470,22 +470,19 @@ def test__image_2d_from__x1_plane__single_plane_tracer(sub_grid_2d_7x7):
     assert tracer_image == pytest.approx(g0_image + g1_image + g2_image, 1.0e-4)
 
 
-def test__image_2d_from__operated_only_input(sub_grid_2d_7x7):
+def test__image_2d_from__operated_only_input(
+    sub_grid_2d_7x7, lp_0, lp_operated_0, mp_0
+):
 
-    light_not_operated = al.lp.EllSersic(intensity=1.0)
-    light_operated = al.lp_operated.EllGaussian(intensity=1.0)
-
-    image_2d_not_operated = light_not_operated.image_2d_from(grid=sub_grid_2d_7x7)
-    image_2d_operated = light_operated.image_2d_from(grid=sub_grid_2d_7x7)
-
-    mass = al.mp.SphIsothermal(einstein_radius=1.0)
+    image_2d_not_operated = lp_0.image_2d_from(grid=sub_grid_2d_7x7)
+    image_2d_operated = lp_operated_0.image_2d_from(grid=sub_grid_2d_7x7)
 
     galaxy_0 = al.Galaxy(
-        redshift=0.5, light=light_not_operated, light_operated=light_operated, mass=mass
+        redshift=0.5, light=lp_0, light_operated=lp_operated_0, mass=mp_0
     )
 
     galaxy_1 = al.Galaxy(
-        redshift=1.0, light_operated_0=light_operated, light_operated_1=light_operated
+        redshift=1.0, light_operated_0=lp_operated_0, light_operated_1=lp_operated_0
     )
     galaxy_2 = al.Galaxy(redshift=2.0)
 
@@ -493,10 +490,8 @@ def test__image_2d_from__operated_only_input(sub_grid_2d_7x7):
 
     source_plane_grid_2d = tracer.traced_grid_2d_list_from(grid=sub_grid_2d_7x7)[1]
 
-    source_image_2d_not_operated = light_not_operated.image_2d_from(
-        grid=source_plane_grid_2d
-    )
-    source_image_2d_operated = light_operated.image_2d_from(grid=source_plane_grid_2d)
+    source_image_2d_not_operated = lp_0.image_2d_from(grid=source_plane_grid_2d)
+    source_image_2d_operated = lp_operated_0.image_2d_from(grid=source_plane_grid_2d)
 
     image_2d = tracer.image_2d_from(grid=sub_grid_2d_7x7, operated_only=False)
     assert image_2d == pytest.approx(image_2d_not_operated, 1.0e-4)
@@ -511,6 +506,30 @@ def test__image_2d_from__operated_only_input(sub_grid_2d_7x7):
         image_2d_not_operated + image_2d_operated + 2.0 * source_image_2d_operated,
         1.0e-4,
     )
+
+
+def test__image_2d_list_from__operated_only_input(
+    sub_grid_2d_7x7, lp_0, lp_operated_0, mp_0
+):
+
+    image_2d_not_operated = lp_0.image_2d_from(grid=sub_grid_2d_7x7)
+    image_2d_operated = lp_operated_0.image_2d_from(grid=sub_grid_2d_7x7)
+
+    galaxy_0 = al.Galaxy(
+        redshift=0.5, light=lp_0, light_operated=lp_operated_0, mass=mp_0
+    )
+
+    galaxy_1 = al.Galaxy(
+        redshift=1.0, light_operated_0=lp_operated_0, light_operated_1=lp_operated_0
+    )
+    galaxy_2 = al.Galaxy(redshift=2.0)
+
+    tracer = al.Tracer.from_galaxies(galaxies=[galaxy_0, galaxy_1, galaxy_2])
+
+    source_plane_grid_2d = tracer.traced_grid_2d_list_from(grid=sub_grid_2d_7x7)[1]
+
+    source_image_2d_not_operated = lp_0.image_2d_from(grid=source_plane_grid_2d)
+    source_image_2d_operated = lp_operated_0.image_2d_from(grid=source_plane_grid_2d)
 
     image_2d_list = tracer.image_2d_list_from(grid=sub_grid_2d_7x7, operated_only=False)
     assert image_2d_list[0] == pytest.approx(image_2d_not_operated, 1.0e-4)

--- a/test_autolens/lens/test_ray_tracing.py
+++ b/test_autolens/lens/test_ray_tracing.py
@@ -376,7 +376,7 @@ def test__galaxies__comes_in_plane_redshift_order(sub_grid_2d_7x7):
 ### Light Profiles ###
 
 
-def test__x1_plane__single_plane_tracer(sub_grid_2d_7x7):
+def test__image_2d_from__x1_plane__single_plane_tracer(sub_grid_2d_7x7):
     g0 = al.Galaxy(redshift=0.5, light_profile=al.lp.EllSersic(intensity=1.0))
     g1 = al.Galaxy(redshift=0.5, light_profile=al.lp.EllSersic(intensity=2.0))
     g2 = al.Galaxy(redshift=0.5, light_profile=al.lp.EllSersic(intensity=3.0))
@@ -447,6 +447,65 @@ def test__x1_plane__single_plane_tracer(sub_grid_2d_7x7):
     tracer_image = tracer.image_2d_from(grid=sub_grid_2d_7x7)
 
     assert tracer_image == pytest.approx(g0_image + g1_image + g2_image, 1.0e-4)
+
+
+def test__image_2d_from__operated_only_input(sub_grid_2d_7x7):
+
+    light_not_operated = al.lp.EllSersic(intensity=1.0)
+    light_operated = al.lp_operated.EllGaussian(intensity=1.0)
+
+    image_2d_not_operated = light_not_operated.image_2d_from(grid=sub_grid_2d_7x7)
+    image_2d_operated = light_operated.image_2d_from(grid=sub_grid_2d_7x7)
+
+    mass = al.mp.SphIsothermal(einstein_radius=1.0)
+
+    galaxy_0 = al.Galaxy(
+        redshift=0.5, light=light_not_operated, light_operated=light_operated, mass=mass
+    )
+
+    galaxy_1 = al.Galaxy(
+        redshift=1.0, light_operated_0=light_operated, light_operated_1=light_operated
+    )
+    galaxy_2 = al.Galaxy(redshift=2.0)
+
+    tracer = al.Tracer.from_galaxies(galaxies=[galaxy_0, galaxy_1, galaxy_2])
+
+    source_plane_grid_2d = tracer.traced_grid_2d_list_from(grid=sub_grid_2d_7x7)[1]
+
+    source_image_2d_not_operated = light_not_operated.image_2d_from(
+        grid=source_plane_grid_2d
+    )
+    source_image_2d_operated = light_operated.image_2d_from(grid=source_plane_grid_2d)
+
+    image_2d = tracer.image_2d_from(grid=sub_grid_2d_7x7, operated_only=False)
+    assert image_2d == pytest.approx(image_2d_not_operated, 1.0e-4)
+
+    image_2d = tracer.image_2d_from(grid=sub_grid_2d_7x7, operated_only=True)
+    assert image_2d == pytest.approx(
+        image_2d_operated + 2.0 * source_image_2d_operated, 1.0e-4
+    )
+
+    image_2d = tracer.image_2d_from(grid=sub_grid_2d_7x7, operated_only=None)
+    assert image_2d == pytest.approx(
+        image_2d_not_operated + image_2d_operated + 2.0 * source_image_2d_operated,
+        1.0e-4,
+    )
+
+    image_2d_list = tracer.image_2d_list_from(grid=sub_grid_2d_7x7, operated_only=False)
+    assert image_2d_list[0] == pytest.approx(image_2d_not_operated, 1.0e-4)
+    assert image_2d_list[1] == pytest.approx(np.zeros((36)), 1.0e-4)
+    assert image_2d_list[2] == pytest.approx(np.zeros((36)), 1.0e-4)
+
+    image_2d_list = tracer.image_2d_list_from(grid=sub_grid_2d_7x7, operated_only=True)
+    assert image_2d_list[0] == pytest.approx(image_2d_operated, 1.0e-4)
+    assert image_2d_list[1] == pytest.approx(2.0 * source_image_2d_operated, 1.0e-4)
+    assert image_2d_list[2] == pytest.approx(np.zeros((36)), 1.0e-4)
+
+    image_2d_list = tracer.image_2d_list_from(grid=sub_grid_2d_7x7, operated_only=None)
+    assert image_2d_list[0] + image_2d_list[1] == pytest.approx(
+        image_2d_not_operated + image_2d_operated + 2.0 * source_image_2d_operated,
+        1.0e-4,
+    )
 
 
 def test__padded_image_2d_from(sub_grid_2d_7x7, grid_2d_iterate_7x7):


### PR DESCRIPTION
This feature adds a new class of LightProfiles, which are already operated on (e.g. convolved with the PSF) and therefore omit convolution via the Convolver / PSF.

This required a large refactor to distinguish between images made that are already operated on and those which are not.