### PR TITLE
Feature/galaxy refactor

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -48,7 +48,9 @@ from autoarray.structures.visibilities import VisibilitiesNoiseMap
 from autogalaxy import cosmology as cosmo
 from autogalaxy.gui.clicker import Clicker
 from autogalaxy.gui.scribbler import Scribbler
-from autogalaxy.galaxy.galaxy import Galaxy, HyperGalaxy, Redshift
+from autogalaxy.galaxy.galaxy import Galaxy
+from autogalaxy.galaxy.hyper import HyperGalaxy
+from autogalaxy.galaxy.redshift import Redshift
 from autogalaxy.analysis.clump_model import ClumpModel
 from autogalaxy.analysis.clump_model import ClumpModelDisabled
 

--- a/docs/api/galaxy.rst
+++ b/docs/api/galaxy.rst
@@ -2,8 +2,8 @@
 Galaxy / Plane / Tracer
 =======================
 
-Galaxy / Plane
---------------
+Galaxy / Plane / Tracer
+-----------------------
 
 .. currentmodule:: autolens
 
@@ -16,3 +16,30 @@ Galaxy / Plane
    Plane
    Tracer
    SettingsLens
+
+To treat the redshift of a galaxy as a free parameter in a model, the ``Redshift`` object must
+be used.
+
+This is because **PyAutoFit** (which handles model-fitting), requires all parameters to be a Python class.
+
+The ``Redshift`` object does not need to be used for general **PyAutoGalaxy** use.
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-class-template.rst
+   :recursive:
+
+    Redshift
+
+By using a ``HyperGalaxy``, the noise-map value in the regions of the image that the galaxy is located
+are increased.
+
+This prevents over-fitting regions of the data where the model does not provide a good fit
+(e.g. where a high chi-squared is inferred).
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-class-template.rst
+   :recursive:
+
+   HyperGalaxy


### PR DESCRIPTION
Refactor `autogalaxy.galaxy.galaxy` to split up `Redshift` and `HyperGalaxy` objects into separate modules.

Adds docs.