### PR TITLE
Output max likelihood tracer in files as tracer.json

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -114,4 +114,4 @@ from autoconf import conf
 
 conf.instance.register(__file__)
 
-__version__ = "2023.7.5.2"
+__version__ = "2023.9.18.4"

--- a/autolens/analysis/analysis.py
+++ b/autolens/analysis/analysis.py
@@ -7,7 +7,7 @@ from scipy.stats import norm
 from typing import Dict, Optional, List, Union
 
 from autoconf import conf
-from autoconf.dictable import to_dict
+from autoconf.dictable import to_dict, output_to_json
 
 import autofit as af
 import autoarray as aa
@@ -345,6 +345,13 @@ class AnalysisDataset(AgAnalysisDataset, AnalysisLensing):
         result
             The result of a model fit, including the non-linear search, samples and maximum likelihood tracer.
         """
+        try:
+            output_to_json(
+                obj=result.max_log_likelihood_tracer,
+                file_path=paths._files_path / "tracer.json"
+            )
+        except AttributeError:
+            pass
 
         mesh_list = ag.util.model.mesh_list_from(model=result.model)
 

--- a/autolens/lens/ray_tracing.py
+++ b/autolens/lens/ray_tracing.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Type, Union
 
 import autoarray as aa
 import autogalaxy as ag
+
 from autoconf.dictable import from_dict, to_dict, output_to_json
 
 from autogalaxy.plane.plane import Plane
@@ -127,21 +128,6 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections):
             )
 
         return Tracer(planes=planes, cosmology=cosmology)
-
-    @staticmethod
-    def from_dict(cls_dict):
-        arguments = cls_dict["arguments"]
-        cosmology = arguments["cosmology"]
-        if isinstance(cosmology, str):
-            arguments["cosmology"] = getattr(ag.cosmo, cosmology)
-        return from_dict(cls_dict)
-
-    def output_to_json(self, file_path):
-
-        tracer_dict = to_dict(self)
-        tracer_dict["cosmology"] = self.cosmology
-
-        output_to_json(obj=tracer_dict, file_path=file_path)
 
     @property
     def galaxies(self) -> List[ag.Galaxy]:

--- a/autolens/lens/ray_tracing.py
+++ b/autolens/lens/ray_tracing.py
@@ -137,7 +137,11 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections):
         return from_dict(cls_dict)
 
     def output_to_json(self, file_path):
-        output_to_json(obj=to_dict(self), file_path=file_path)
+
+        tracer_dict = to_dict(self)
+        tracer_dict["cosmology"] = self.cosmology
+
+        output_to_json(obj=tracer_dict, file_path=file_path)
 
     @property
     def galaxies(self) -> List[ag.Galaxy]:

--- a/docs/installation/conda.rst
+++ b/docs/installation/conda.rst
@@ -47,7 +47,7 @@ You may get warnings which state something like:
 
 .. code-block:: bash
 
-    ERROR: autoarray 2023.7.5.2 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
+    ERROR: autoarray 2023.9.18.4 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
     ERROR: numba 0.53.1 has requirement llvmlite<0.37,>=0.36.0rc1, but you'll have llvmlite 0.38.0 which is incompatible.
 
 If you see these messages, they do not mean that the installation has failed and the instructions below will

--- a/docs/installation/pip.rst
+++ b/docs/installation/pip.rst
@@ -27,7 +27,7 @@ You may get warnings which state something like:
 
 .. code-block:: bash
 
-    ERROR: autoarray 2023.7.5.2 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
+    ERROR: autoarray 2023.9.18.4 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
     ERROR: numba 0.53.1 has requirement llvmlite<0.37,>=0.36.0rc1, but you'll have llvmlite 0.38.0 which is incompatible.
 
 If you see these messages, they do not mean that the installation has failed and the instructions below will

--- a/test_autolens/analysis/test_analysis.py
+++ b/test_autolens/analysis/test_analysis.py
@@ -188,7 +188,7 @@ def test__check_preloads(masked_imaging_7x7):
         analysis.preloads.check_via_fit(fit=fit)
 
 
-def test__tracer__output_to_json(analysis_imaging_7x7):
+def test__save_results__tracer_output_to_json(analysis_imaging_7x7):
 
     lens = al.Galaxy(redshift=0.5)
     source = al.Galaxy(redshift=1.0)
@@ -196,7 +196,7 @@ def test__tracer__output_to_json(analysis_imaging_7x7):
     model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
 
     tracer = al.Tracer.from_galaxies(
-        galaxies=[al.Galaxy(redshift=0.5), al.Galaxy(redshift=1.0)]
+        galaxies=[lens, source]
     )
 
     paths = af.DirectoryPaths()

--- a/test_autolens/analysis/test_analysis.py
+++ b/test_autolens/analysis/test_analysis.py
@@ -1,8 +1,11 @@
 import numpy as np
 from os import path
+import os
 import pytest
 
 from autoconf import conf
+from autoconf.dictable import from_json
+
 import autofit as af
 import autolens as al
 from autolens import exc
@@ -183,3 +186,29 @@ def test__check_preloads(masked_imaging_7x7):
 
     with pytest.raises(exc.PreloadsException):
         analysis.preloads.check_via_fit(fit=fit)
+
+
+def test__tracer__output_to_json(analysis_imaging_7x7):
+
+    lens = al.Galaxy(redshift=0.5)
+    source = al.Galaxy(redshift=1.0)
+
+    model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+    tracer = al.Tracer.from_galaxies(
+        galaxies=[al.Galaxy(redshift=0.5), al.Galaxy(redshift=1.0)]
+    )
+
+    paths = af.DirectoryPaths()
+
+    analysis_imaging_7x7.save_results(
+        paths=paths,
+        result=al.m.MockResult(max_log_likelihood_tracer=tracer, model=model)
+    )
+
+    tracer = from_json(file_path=paths._files_path / "tracer.json")
+
+    assert tracer.galaxies[0].redshift == 0.5
+    assert tracer.galaxies[1].redshift == 1.0
+
+    os.remove(paths._files_path / "tracer.json")

--- a/test_autolens/lens/test_dict.py
+++ b/test_autolens/lens/test_dict.py
@@ -1,7 +1,7 @@
 import pytest
 
 import autolens as al
-from autoconf.dictable import to_dict
+from autoconf.dictable import to_dict, from_dict
 
 
 @pytest.fixture(name="tracer")
@@ -105,9 +105,9 @@ def make_tracer_dict():
     }
 
 
-def test_to_dict(tracer, tracer_dict):
+def test__to_dict(tracer, tracer_dict):
     assert to_dict(tracer) == tracer_dict
 
 
-def test_from_dict(tracer, tracer_dict):
-    assert tracer.from_dict(tracer_dict) == tracer
+def test__from_dict(tracer, tracer_dict):
+    assert from_dict(tracer_dict) == tracer

--- a/test_autolens/lens/test_ray_tracing.py
+++ b/test_autolens/lens/test_ray_tracing.py
@@ -1564,6 +1564,8 @@ def test__output_to_and_load_from_json():
 
     tracer_from_json = from_json(file_path=json_file)
 
+    print(type(tracer_from_json))
+
     assert tracer_from_json.galaxies[0].redshift == 0.5
     assert tracer_from_json.galaxies[1].redshift == 1.0
     assert tracer_from_json.galaxies[0].mass_profile.einstein_radius == 1.0


### PR DESCRIPTION
When a model-fit completes, the maximum likelihood tracer is output to the `files` folder as a .json file.

