### PR TITLE
autoconf dictable imports

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -1,3 +1,4 @@
+from autoconf.dictable import from_dict, from_json, output_to_json, to_dict
 from autoarray import preprocess
 from autoarray.dataset.imaging.w_tilde import WTildeImaging
 from autoarray.dataset.imaging.imaging import Imaging, SettingsImaging

--- a/docs/advanced/database.rst
+++ b/docs/advanced/database.rst
@@ -21,7 +21,7 @@ to the non-linear search:
     session = af.db.open_database("database.sqlite")
 
     emcee = af.Emcee(
-        session=session,  # This instructs the search to write to the .sqlite database.
+        session=session,  # This can instruct the search to write to the .sqlite database.
     )
 
 When a model-fit is performed, a unique identifier is generated based on the model and non-linear search. However,
@@ -40,7 +40,7 @@ alongside the model and search to create the unique identifier:
     emcee = af.Emcee(
         path_prefix=path.join("features", "database"),
         unique_tag=dataset_name,  # This makes the unique identifier use the dataset name
-        session=session,  # This instructs the search to write to the .sqlite database.
+        session=session,  # This can instruct the search to write to the .sqlite database.
     )
 
 Lets suppose that we have performed 100 model-fits to 100 strong lenses, and when we ran **PyAutoLens** we told it


### PR DESCRIPTION
Makes dictable methods in `PyAutoConf` which output classes to `dict` / `json` formats accessible via simple import, which is used in most workspace examples.