### PR TITLE
Feature/adapt data

### DIFF
--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 from typing import Dict, List, Optional
 
@@ -180,6 +181,26 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         )
 
         return {**galaxy_blurred_image_2d_dict, **galaxy_linear_obj_image_dict}
+
+    @property
+    def subtracted_image_of_galaxies_dict(self) -> Dict[ag.Galaxy, np.ndarray]:
+        """
+        A dictionary associating galaxies with their subtracted image, where:
+
+        Subtracted Image = Blurred Image - Galaxy Model Image
+        """
+
+        subtracted_image_of_galaxies_dict = {}
+
+        for (galaxy, galaxy_model_image) in self.galaxy_model_image_dict.items():
+            subtracted_image_of_galaxies_dict[galaxy] = copy.copy(self.dataset.data)
+
+        for (galaxy, galaxy_model_image) in self.galaxy_model_image_dict.items():
+            for (galaxy_other, galaxy_model_image_other) in self.galaxy_model_image_dict.items():
+                if galaxy != galaxy_other:
+                    subtracted_image_of_galaxies_dict[galaxy] -= galaxy_model_image_other
+
+        return subtracted_image_of_galaxies_dict
 
     @property
     def model_images_of_planes_list(self) -> List[aa.Array2D]:

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -183,24 +183,27 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         return {**galaxy_blurred_image_2d_dict, **galaxy_linear_obj_image_dict}
 
     @property
-    def subtracted_image_of_galaxies_dict(self) -> Dict[ag.Galaxy, np.ndarray]:
+    def subtracted_images_of_galaxies_dict(self) -> Dict[ag.Galaxy, np.ndarray]:
         """
-        A dictionary associating galaxies with their subtracted image, where:
+        A dictionary which associates every galaxy in the tracer with its `subtracted image`.
 
-        Subtracted Image = Blurred Image - Galaxy Model Image
+        A subtracted image of a galaxy is the data where all other galaxy images are subtracted from it, therefore
+        showing how a galaxy appears in the data in the absence of all other galaxies.
+
+        This is used to visualize the contribution of each galaxy in the data.
         """
 
-        subtracted_image_of_galaxies_dict = {}
+        subtracted_images_of_galaxies_dict = {}
 
         for (galaxy, galaxy_model_image) in self.galaxy_model_image_dict.items():
-            subtracted_image_of_galaxies_dict[galaxy] = copy.copy(self.dataset.data)
+            subtracted_images_of_galaxies_dict[galaxy] = copy.copy(self.dataset.data)
 
         for (galaxy, galaxy_model_image) in self.galaxy_model_image_dict.items():
             for (galaxy_other, galaxy_model_image_other) in self.galaxy_model_image_dict.items():
                 if galaxy != galaxy_other:
-                    subtracted_image_of_galaxies_dict[galaxy] -= galaxy_model_image_other
+                    subtracted_images_of_galaxies_dict[galaxy] -= galaxy_model_image_other
 
-        return subtracted_image_of_galaxies_dict
+        return subtracted_images_of_galaxies_dict
 
     @property
     def model_images_of_planes_list(self) -> List[aa.Array2D]:

--- a/test_autolens/analysis/test_result.py
+++ b/test_autolens/analysis/test_result.py
@@ -366,14 +366,14 @@ def test___image_dict(analysis_imaging_7x7):
         analysis=analysis_imaging_7x7,
     )
 
-    image_dict = result.image_galaxy_dict
+    image_dict = result.model_image_galaxy_dict
 
     assert isinstance(image_dict[str(("galaxies", "lens"))], Array2D)
     assert isinstance(image_dict[str(("galaxies", "source"))], Array2D)
 
     result.instance.galaxies.lens = al.Galaxy(redshift=0.5)
 
-    image_dict = result.image_galaxy_dict
+    image_dict = result.model_image_galaxy_dict
 
     assert (image_dict[str(("galaxies", "lens"))].native == np.zeros((7, 7))).all()
     assert isinstance(image_dict[str(("galaxies", "source"))], Array2D)

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -416,7 +416,9 @@ def test__subtracted_image_of_galaxies_dict(masked_imaging_7x7):
     assert fit.subtracted_images_of_galaxies_dict[g1] == pytest.approx(
         masked_imaging_7x7.data - blurred_image_2d_list[0] - blurred_image_2d_list[2], 1.0e-4
     )
-    assert (fit.subtracted_images_of_galaxies_dict[g2] == masked_imaging_7x7.data - blurred_image_2d_list[0] - blurred_image_2d_list[1]).all()
+    assert fit.subtracted_images_of_galaxies_dict[g2] == pytest.approx(
+        masked_imaging_7x7.data - blurred_image_2d_list[0] - blurred_image_2d_list[1], 1.0e-4
+    )
 
 
 

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -362,15 +362,23 @@ def test__subtracted_image_of_galaxies_dict(masked_imaging_7x7):
 
     fit = al.FitImaging(dataset=masked_imaging_7x7, tracer=tracer)
 
-    blurred_image_2d_list = tracer.blurred_image_2d_list_from(
+    g0_image = g0.blurred_image_2d_from(
         grid=masked_imaging_7x7.grid,
-        convolver=masked_imaging_7x7.convolver,
         blurring_grid=masked_imaging_7x7.blurring_grid,
+        convolver=masked_imaging_7x7.convolver
     )
 
-    g0_image = g0.blurred_image_2d_from(grid=masked_imaging_7x7.grid, blurring_grid=masked_imaging_7x7.blurring_grid, convolver=masked_imaging_7x7.convolver)
-    g1_image = g1.blurred_image_2d_from(grid=masked_imaging_7x7.grid, blurring_grid=masked_imaging_7x7.blurring_grid, convolver=masked_imaging_7x7.convolver)
-    g2_image = g2.blurred_image_2d_from(grid=masked_imaging_7x7.grid, blurring_grid=masked_imaging_7x7.blurring_grid, convolver=masked_imaging_7x7.convolver)
+    g1_image = g1.blurred_image_2d_from(
+        grid=masked_imaging_7x7.grid,
+        blurring_grid=masked_imaging_7x7.blurring_grid,
+        convolver=masked_imaging_7x7.convolver
+    )
+
+    g2_image = g2.blurred_image_2d_from(
+        grid=masked_imaging_7x7.grid,
+        blurring_grid=masked_imaging_7x7.blurring_grid,
+        convolver=masked_imaging_7x7.convolver
+    )
 
     assert fit.subtracted_image_of_galaxies_dict[g0] == pytest.approx(
         masked_imaging_7x7.data - g1_image - g2_image, 1.0e-4

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -380,13 +380,13 @@ def test__subtracted_image_of_galaxies_dict(masked_imaging_7x7):
         convolver=masked_imaging_7x7.convolver
     )
 
-    assert fit.subtracted_image_of_galaxies_dict[g0] == pytest.approx(
+    assert fit.subtracted_images_of_galaxies_dict[g0] == pytest.approx(
         masked_imaging_7x7.data - g1_image - g2_image, 1.0e-4
     )
-    assert fit.subtracted_image_of_galaxies_dict[g1] == pytest.approx(
+    assert fit.subtracted_images_of_galaxies_dict[g1] == pytest.approx(
         masked_imaging_7x7.data - g0_image - g2_image, 1.0e-4
     )
-    assert fit.subtracted_image_of_galaxies_dict[g2] == pytest.approx(
+    assert fit.subtracted_images_of_galaxies_dict[g2] == pytest.approx(
         masked_imaging_7x7.data - g0_image - g1_image, 1.0e-4
     )
 
@@ -410,13 +410,13 @@ def test__subtracted_image_of_galaxies_dict(masked_imaging_7x7):
         blurring_grid=masked_imaging_7x7.blurring_grid,
     )
 
-    assert fit.subtracted_image_of_galaxies_dict[g0] == pytest.approx(
+    assert fit.subtracted_images_of_galaxies_dict[g0] == pytest.approx(
         masked_imaging_7x7.data - blurred_image_2d_list[1] - blurred_image_2d_list[2], 1.0e-4
     )
-    assert fit.subtracted_image_of_galaxies_dict[g1] == pytest.approx(
+    assert fit.subtracted_images_of_galaxies_dict[g1] == pytest.approx(
         masked_imaging_7x7.data - blurred_image_2d_list[0] - blurred_image_2d_list[2], 1.0e-4
     )
-    assert (fit.subtracted_image_of_galaxies_dict[g2] == masked_imaging_7x7.data - blurred_image_2d_list[0] - blurred_image_2d_list[1]).all()
+    assert (fit.subtracted_images_of_galaxies_dict[g2] == masked_imaging_7x7.data - blurred_image_2d_list[0] - blurred_image_2d_list[1]).all()
 
 
 


### PR DESCRIPTION
Can now choose whether the `adapt_images` of a fit use the `model_image` of each galaxy or the `subtracted_image`, which is the image of the data minus all other galaxies images.

For PyAutoLens this would be the lens subtracted image.

API:

```
result.adapt_images_from(use_model_images=True)

result.adapt_images_from(use_model_images=False) # Subtracted images
```