### PR TITLE
rename subtracted_signal_to_noise_map_of_galaxies

### DIFF
--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -206,6 +206,25 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         return subtracted_images_of_galaxies_dict
 
     @property
+    def subtracted_signal_to_noise_maps_of_galaxies_dict(self) -> Dict[ag.Galaxy, np.ndarray]:
+        """
+        A dictionary which associates every galaxy in the tracer with its `subtracted image`.
+
+        A subtracted image of a galaxy is the data where all other galaxy images are subtracted from it, therefore
+        showing how a galaxy appears in the data in the absence of all other galaxies.
+
+        This is used to visualize the contribution of each galaxy in the data.
+        """
+
+        subtracted_signal_to_noise_maps_of_galaxies_dict = {}
+
+        for (galaxy, subtracted_image) in self.subtracted_images_of_galaxies_dict.items():
+
+            subtracted_signal_to_noise_maps_of_galaxies_dict[galaxy] = subtracted_image / self.noise_map
+
+        return subtracted_signal_to_noise_maps_of_galaxies_dict
+
+    @property
     def model_images_of_planes_list(self) -> List[aa.Array2D]:
         """
         A list of every model image of every plane in the tracer.

--- a/autolens/interferometer/model/result.py
+++ b/autolens/interferometer/model/result.py
@@ -3,6 +3,7 @@ import numpy as np
 import autoarray as aa
 import autogalaxy as ag
 
+from autogalaxy.analysis.adapt_images import AdaptImages
 from autolens.lens.ray_tracing import Tracer
 from autolens.interferometer.fit_interferometer import FitInterferometer
 from autolens.analysis.result import ResultDataset
@@ -67,3 +68,29 @@ class ResultInterferometer(ResultDataset):
         The real space mask used by this model-fit.
         """
         return self.max_log_likelihood_fit.dataset.real_space_mask
+
+    def adapt_images_from(self, use_model_images : bool = False) -> AdaptImages:
+        """
+        Returns the adapt-images which are used to make a pixelization's mesh and regularization adapt to the
+        reconstructed galaxy's morphology.
+
+        This can use either:
+
+        - The model image of each galaxy in the best-fit model.
+        - The subtracted image of each galaxy in the best-fit model, where the subtracted image is the dataset
+          minus the model images of all other galaxies.
+
+        In **PyAutoLens** these adapt images have had lensing calculations performed on them and therefore for source
+        galaxies are their lensed model images in the image-plane.
+
+        Parameters
+        ----------
+        use_model_images
+            If True, the model images of the galaxies are used to create the adapt images. If False, the subtracted
+            images of the galaxies are used.
+        """
+
+        return AdaptImages.from_result(
+            result=self,
+            use_model_images=True
+        )


### PR DESCRIPTION
Adapt images now use the lens subtracted signal-to-noise map by default, retaining the option to use the model image.