### PR TITLE
Sky Background Modeling

### DIFF
--- a/autolens/imaging/model/analysis.py
+++ b/autolens/imaging/model/analysis.py
@@ -156,6 +156,8 @@ class AnalysisImaging(AnalysisDataset):
             instance=instance, run_time_dict=run_time_dict
         )
 
+        sky = self.sky_via_instance_from(instance=instance)
+
         adapt_images = self.adapt_images_via_instance_from(instance=instance)
 
         preloads = preload_overwrite or self.preloads
@@ -163,6 +165,7 @@ class AnalysisImaging(AnalysisDataset):
         return FitImaging(
             dataset=self.dataset,
             tracer=tracer,
+            sky=sky,
             adapt_images=adapt_images,
             settings_inversion=self.settings_inversion,
             preloads=preloads,

--- a/autolens/imaging/plot/fit_imaging_plotters.py
+++ b/autolens/imaging/plot/fit_imaging_plotters.py
@@ -467,7 +467,11 @@ class FitImagingPlotter(Plotter):
 
         self.set_title(label=None)
 
-        self.figures_2d(signal_to_noise_map=True)
+        try:
+            self.figures_2d(signal_to_noise_map=True)
+        except ValueError:
+            pass
+
         self.figures_2d(model_image=True)
 
         self.set_title(label="Lens Light Model Image")

--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -84,7 +84,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
 
         super().__init__(dataset=dataset, run_time_dict=run_time_dict)
         AbstractFitInversion.__init__(
-            self=self, model_obj=tracer, settings_inversion=settings_inversion
+            self=self, model_obj=tracer, sky=None, settings_inversion=settings_inversion
         )
 
     @property

--- a/autolens/interferometer/model/analysis.py
+++ b/autolens/interferometer/model/analysis.py
@@ -328,11 +328,7 @@ class AnalysisInterferometer(AnalysisDataset):
             except IndexError:
                 pass
 
-    def make_result(
-        self,
-        samples: af.SamplesPDF,
-            search_internal = None
-    ):
+    def make_result(self, samples: af.SamplesPDF, search_internal=None):
         """
         After the non-linear search is complete create its `Result`, which includes:
 
@@ -358,7 +354,9 @@ class AnalysisInterferometer(AnalysisDataset):
         ResultImaging
             The result of fitting the model to the imaging dataset, via a non-linear search.
         """
-        return ResultInterferometer(samples=samples, analysis=self, search_internal=search_internal)
+        return ResultInterferometer(
+            samples=samples, analysis=self, search_internal=search_internal
+        )
 
     def save_attributes(self, paths: af.DirectoryPaths):
         """

--- a/autolens/lens/to_inversion.py
+++ b/autolens/lens/to_inversion.py
@@ -72,6 +72,7 @@ class TracerToInversion(ag.AbstractToInversion):
         for plane_index, galaxies in enumerate(self.planes):
             plane_to_inversion = ag.GalaxiesToInversion(
                 galaxies=galaxies,
+                sky=self.sky,
                 dataset=self.dataset,
                 grid=traced_grids_of_planes_list[plane_index],
                 blurring_grid=traced_blurring_grids_of_planes_list[plane_index],
@@ -135,6 +136,7 @@ class TracerToInversion(ag.AbstractToInversion):
         for galaxies in self.planes:
             to_inversion = ag.GalaxiesToInversion(
                 galaxies=galaxies,
+                sky=self.sky,
                 grid_pixelization=self.dataset.grid,
                 noise_map=self.noise_map,
                 adapt_images=self.adapt_images,
@@ -208,6 +210,7 @@ class TracerToInversion(ag.AbstractToInversion):
             if galaxies.has(cls=aa.Pixelization):
                 to_inversion = ag.GalaxiesToInversion(
                     galaxies=galaxies,
+                    sky=self.sky,
                     grid_pixelization=traced_grids_of_planes_list[plane_index],
                     preloads=self.preloads,
                     noise_map=self.noise_map,

--- a/autolens/lens/to_inversion.py
+++ b/autolens/lens/to_inversion.py
@@ -6,7 +6,7 @@ import autoarray as aa
 import autogalaxy as ag
 
 from autoarray.inversion.inversion.factory import inversion_unpacked_from
-
+from autogalaxy.profiles.light.basis import Basis
 from autolens.analysis.preloads import Preloads
 
 
@@ -18,6 +18,7 @@ class TracerToInversion(ag.AbstractToInversion):
         data: Optional[Union[aa.Array2D, aa.Visibilities]] = None,
         noise_map: Optional[Union[aa.Array2D, aa.VisibilitiesNoiseMap]] = None,
         w_tilde: Optional[Union[aa.WTildeImaging, aa.WTildeInterferometer]] = None,
+        sky: Optional[Basis] = None,
         adapt_images: Optional[ag.AdaptImages] = None,
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads=Preloads(),
@@ -30,6 +31,7 @@ class TracerToInversion(ag.AbstractToInversion):
             data=data,
             noise_map=noise_map,
             w_tilde=w_tilde,
+            sky=sky,
             adapt_images=adapt_images,
             settings_inversion=settings_inversion,
             preloads=preloads,

--- a/autolens/point/model/analysis.py
+++ b/autolens/point/model/analysis.py
@@ -101,9 +101,11 @@ class AnalysisPoint(AgAnalysis, AnalysisLensing):
     def make_result(
         self,
         samples: af.SamplesPDF,
-            search_internal = None,
+        search_internal=None,
     ):
-        return ResultPoint(samples=samples, analysis=self, search_internal=search_internal)
+        return ResultPoint(
+            samples=samples, analysis=self, search_internal=search_internal
+        )
 
     def save_attributes(self, paths: af.DirectoryPaths):
         self.point_dict.output_to_json(

--- a/autolens/quantity/model/analysis.py
+++ b/autolens/quantity/model/analysis.py
@@ -127,7 +127,7 @@ class AnalysisQuantity(ag.AnalysisQuantity, AnalysisLensing):
     def make_result(
         self,
         samples: af.SamplesPDF,
-        search_internal = None,
+        search_internal=None,
     ) -> ResultQuantity:
         """
         After the non-linear search is complete create its `ResultQuantity`, which includes:
@@ -156,4 +156,6 @@ class AnalysisQuantity(ag.AnalysisQuantity, AnalysisLensing):
         ResultQuantity
             The result of fitting the model to the imaging dataset, via a non-linear search.
         """
-        return ResultQuantity(samples=samples, analysis=self, search_internal=search_internal)
+        return ResultQuantity(
+            samples=samples, analysis=self, search_internal=search_internal
+        )

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -256,12 +256,12 @@ def test__fit__sky___handles_special_behaviour(masked_imaging_7x7):
     )
 
     assert fit.perform_inversion is True
-    assert fit.figure_of_merit == pytest.approx(-2859741.44762, 1.0e-4)
+    assert fit.figure_of_merit == pytest.approx(-733125.35694344, 1.0e-4)
 
     sky = fit.sky_linear_light_profiles_to_light_profiles
 
-    assert sky.light_profile_list[0].intensity == pytest.approx(-49.5, 1.0e-4)
-    assert sky.light_profile_list[1].intensity == pytest.approx(49.5, 1.0e-4)
+    assert sky.light_profile_list[0].intensity == pytest.approx(-737.44550397, 1.0e-4)
+    assert sky.light_profile_list[1].intensity == pytest.approx(737.44550397, 1.0e-4)
 
     fit = al.FitImaging(
         dataset=masked_imaging_7x7,
@@ -271,24 +271,19 @@ def test__fit__sky___handles_special_behaviour(masked_imaging_7x7):
     )
 
     assert fit.perform_inversion is True
-    assert fit.figure_of_merit == pytest.approx(-2859741.44762, 1.0e-4)
+    assert fit.figure_of_merit == pytest.approx(-733125.3569434, 1.0e-4)
 
     sky = fit.sky_linear_light_profiles_to_light_profiles
 
     assert sky.light_profile_list[0].intensity == pytest.approx(0.0, 1.0e-4)
-    assert sky.light_profile_list[1].intensity == pytest.approx(99.0, 1.0e-4)
-
-    g0_light = al.Galaxy(
-        redshift=0.5,
-        bulge=al.lp_linear.Sersic(sersic_index=1.0),
-    )
+    assert sky.light_profile_list[1].intensity == pytest.approx(1474.891048, 1.0e-4)
 
     fit = al.FitImaging(
         dataset=masked_imaging_7x7, tracer=tracer, sky=al.lp.Sky(intensity=-99.0)
     )
 
-    assert fit.perform_inversion is True
-    assert fit.figure_of_merit == pytest.approx(-14.5087714, 1.0e-4)
+    assert fit.perform_inversion is False
+    assert fit.figure_of_merit == pytest.approx(-2862836.077500, 1.0e-4)
 
 
 def test__galaxy_model_image_dict(masked_imaging_7x7):

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 import pytest
 
@@ -229,6 +230,65 @@ def test__fit_figure_of_merit(masked_imaging_7x7, masked_imaging_covariance_7x7)
 
     assert fit.perform_inversion is True
     assert fit.figure_of_merit == pytest.approx(-341415.8258823, 1.0e-4)
+
+
+def test__fit__sky___handles_special_behaviour(masked_imaging_7x7):
+    masked_imaging_7x7 = copy.copy(masked_imaging_7x7)
+
+    masked_imaging_7x7.data -= 100.0
+
+    g0 = al.Galaxy(
+        redshift=0.5,
+        bulge=al.lp.Sersic(intensity=1.0),
+        disk=al.lp.Sersic(intensity=2.0),
+        mass_profile=al.mp.IsothermalSph(einstein_radius=1.0),
+    )
+
+    g1 = al.Galaxy(redshift=1.0, bulge=al.lp.Sersic(intensity=1.0))
+
+    tracer = al.Tracer(galaxies=[g0, g1])
+
+    fit = al.FitImaging(
+        dataset=masked_imaging_7x7,
+        tracer=tracer,
+        sky=al.lp_linear.Sky(),
+        settings_inversion=al.SettingsInversion(use_positive_only_solver=False),
+    )
+
+    assert fit.perform_inversion is True
+    assert fit.figure_of_merit == pytest.approx(-2859741.44762, 1.0e-4)
+
+    sky = fit.sky_linear_light_profiles_to_light_profiles
+
+    assert sky.light_profile_list[0].intensity == pytest.approx(-49.5, 1.0e-4)
+    assert sky.light_profile_list[1].intensity == pytest.approx(49.5, 1.0e-4)
+
+    fit = al.FitImaging(
+        dataset=masked_imaging_7x7,
+        tracer=tracer,
+        sky=al.lp_linear.Sky(),
+        settings_inversion=al.SettingsInversion(use_positive_only_solver=True),
+    )
+
+    assert fit.perform_inversion is True
+    assert fit.figure_of_merit == pytest.approx(-2859741.44762, 1.0e-4)
+
+    sky = fit.sky_linear_light_profiles_to_light_profiles
+
+    assert sky.light_profile_list[0].intensity == pytest.approx(0.0, 1.0e-4)
+    assert sky.light_profile_list[1].intensity == pytest.approx(99.0, 1.0e-4)
+
+    g0_light = al.Galaxy(
+        redshift=0.5,
+        bulge=al.lp_linear.Sersic(sersic_index=1.0),
+    )
+
+    fit = al.FitImaging(
+        dataset=masked_imaging_7x7, tracer=tracer, sky=al.lp.Sky(intensity=-99.0)
+    )
+
+    assert fit.perform_inversion is True
+    assert fit.figure_of_merit == pytest.approx(-14.5087714, 1.0e-4)
 
 
 def test__galaxy_model_image_dict(masked_imaging_7x7):


### PR DESCRIPTION
The sky background can now be included in a model-fit, either as a non-linear light profile or linear light profile.

A full description of this feature is given here:

https://github.com/Jammy2211/autolens_workspace/blob/main/notebooks/imaging/modeling/features/advanced/sky_background.ipynb