### PR TITLE
Feature/samples summary in result

### DIFF
--- a/autolens/imaging/model/analysis.py
+++ b/autolens/imaging/model/analysis.py
@@ -283,8 +283,10 @@ class AnalysisImaging(AnalysisDataset):
 
     def make_result(
         self,
-        samples: af.SamplesPDF,
-        search_internal = None
+        samples_summary: af.SamplesSummary,
+        paths: af.AbstractPaths,
+        samples: Optional[af.SamplesPDF] = None,
+        search_internal: Optional[object] = None,
     ) -> ResultImaging:
         """
         After the non-linear search is complete create its `Result`, which includes:
@@ -311,7 +313,7 @@ class AnalysisImaging(AnalysisDataset):
         ResultImaging
             The result of fitting the model to the imaging dataset, via a non-linear search.
         """
-        return ResultImaging(samples=samples, analysis=self, search_internal=search_internal)
+        return ResultImaging(samples_summary=samples_summary, paths=paths, samples=samples, search_internal=search_internal, analysis=self)
 
     def save_attributes(self, paths: af.DirectoryPaths):
         """

--- a/autolens/interferometer/model/analysis.py
+++ b/autolens/interferometer/model/analysis.py
@@ -328,7 +328,13 @@ class AnalysisInterferometer(AnalysisDataset):
             except IndexError:
                 pass
 
-    def make_result(self, samples: af.SamplesPDF, search_internal=None):
+    def make_result(
+        self,
+        samples_summary: af.SamplesSummary,
+        paths: af.AbstractPaths,
+        samples: Optional[af.SamplesPDF] = None,
+        search_internal: Optional[object] = None,
+    ):
         """
         After the non-linear search is complete create its `Result`, which includes:
 
@@ -355,7 +361,11 @@ class AnalysisInterferometer(AnalysisDataset):
             The result of fitting the model to the imaging dataset, via a non-linear search.
         """
         return ResultInterferometer(
-            samples=samples, analysis=self, search_internal=search_internal
+            samples_summary=samples_summary,
+            paths=paths,
+            samples=samples,
+            analysis=self,
+            search_internal=search_internal
         )
 
     def save_attributes(self, paths: af.DirectoryPaths):

--- a/autolens/lens/to_inversion.py
+++ b/autolens/lens/to_inversion.py
@@ -70,7 +70,7 @@ class TracerToInversion(ag.AbstractToInversion):
             )
 
         for plane_index, galaxies in enumerate(self.planes):
-            plane_to_inversion = ag.GalaxiesToInversion(
+            galaxies_to_inversion = ag.GalaxiesToInversion(
                 galaxies=galaxies,
                 sky=self.sky,
                 dataset=self.dataset,
@@ -82,7 +82,7 @@ class TracerToInversion(ag.AbstractToInversion):
             )
 
             lp_linear_galaxy_dict_of_plane = (
-                plane_to_inversion.lp_linear_func_list_galaxy_dict
+                galaxies_to_inversion.lp_linear_func_list_galaxy_dict
             )
 
             lp_linear_galaxy_dict_list = {

--- a/autolens/point/model/analysis.py
+++ b/autolens/point/model/analysis.py
@@ -100,11 +100,17 @@ class AnalysisPoint(AgAnalysis, AnalysisLensing):
 
     def make_result(
         self,
-        samples: af.SamplesPDF,
-        search_internal=None,
+        samples_summary: af.SamplesSummary,
+        paths: af.AbstractPaths,
+        samples: Optional[af.SamplesPDF] = None,
+        search_internal: Optional[object] = None,
     ):
         return ResultPoint(
-            samples=samples, analysis=self, search_internal=search_internal
+            samples_summary=samples_summary,
+            paths=paths,
+            samples=samples,
+            search_internal=search_internal,
+            analysis=self,
         )
 
     def save_attributes(self, paths: af.DirectoryPaths):

--- a/autolens/point/point_solver.py
+++ b/autolens/point/point_solver.py
@@ -232,8 +232,8 @@ class AbstractPointSolver:
         )
 
         grid_within_distance_of_centre = grid_within_distance(
-            distances_1d=source_plane_distances,
-            grid_slim=grid,
+            distances_1d=np.asarray(source_plane_distances),
+            grid_slim=np.asarray(grid),
             within_distance=distance,
         )
 

--- a/autolens/quantity/model/analysis.py
+++ b/autolens/quantity/model/analysis.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 import autofit as af
 import autogalaxy as ag
@@ -126,8 +127,10 @@ class AnalysisQuantity(ag.AnalysisQuantity, AnalysisLensing):
 
     def make_result(
         self,
-        samples: af.SamplesPDF,
-        search_internal=None,
+        samples_summary: af.SamplesSummary,
+        paths: af.AbstractPaths,
+        samples: Optional[af.SamplesPDF] = None,
+        search_internal: Optional[object] = None,
     ) -> ResultQuantity:
         """
         After the non-linear search is complete create its `ResultQuantity`, which includes:
@@ -157,5 +160,9 @@ class AnalysisQuantity(ag.AnalysisQuantity, AnalysisLensing):
             The result of fitting the model to the imaging dataset, via a non-linear search.
         """
         return ResultQuantity(
-            samples=samples, analysis=self, search_internal=search_internal
+            samples_summary=samples_summary,
+            paths=paths,
+            samples=samples,
+            search_internal=search_internal,
+            analysis=self
         )

--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -56,11 +56,9 @@ by **PyAutoGalaxy**.
    :template: custom-class-template.rst
    :recursive:
 
-   DynestyPlotter
-   UltraNestPlotter
-   EmceePlotter
-   ZeusPlotter
-   PySwarmsPlotter
+   NestPlotter
+   MCMCPlotter
+   OptimizePlotter
 
 Plot Customization [aplt]
 -------------------------

--- a/docs/overview/overview_3_modeling.rst
+++ b/docs/overview/overview_3_modeling.rst
@@ -523,7 +523,7 @@ mass its name ``mass`` defined when making the ``Model`` above is used).
 
 .. code-block:: python
 
-    search_plotter = aplt.DynestyPlotter(samples=result.samples)
+    search_plotter = aplt.NestPlotter(samples=result.samples)
     search_plotter.corner()
 
 Here is an example of how a PDF estimated for a lens model appears:

--- a/docs/overview/overview_3_modeling.rst
+++ b/docs/overview/overview_3_modeling.rst
@@ -524,7 +524,7 @@ mass its name ``mass`` defined when making the ``Model`` above is used).
 .. code-block:: python
 
     search_plotter = aplt.NestPlotter(samples=result.samples)
-    search_plotter.corner()
+    search_plotter.corner_cornerpy()
 
 Here is an example of how a PDF estimated for a lens model appears:
 

--- a/test_autolens/aggregator/conftest.py
+++ b/test_autolens/aggregator/conftest.py
@@ -66,10 +66,6 @@ def make_model():
 
 @pytest.fixture(name="samples")
 def make_samples(model):
-    galaxy_0 = al.Galaxy(redshift=0.5, light=al.lp.Sersic(centre=(0.0, 1.0)))
-    galaxy_1 = al.Galaxy(redshift=1.0, light=al.lp.Sersic())
-
-    tracer = al.Tracer(galaxies=[galaxy_0, galaxy_1])
 
     parameters = [model.prior_count * [1.0], model.prior_count * [10.0]]
 
@@ -84,6 +80,5 @@ def make_samples(model):
     return al.m.MockSamples(
         model=model,
         sample_list=sample_list,
-        max_log_likelihood_instance=tracer,
         prior_means=[1.0] * model.prior_count,
     )

--- a/test_autolens/analysis/test_result.py
+++ b/test_autolens/analysis/test_result.py
@@ -23,13 +23,7 @@ def test__max_log_likelihood_tracer(
         )
     )
 
-    samples = al.m.MockSamples(
-        model=model,
-        max_log_likelihood_instance=tracer_x2_plane_7x7,
-        prior_means=[1.0] * model.prior_count,
-    )
-
-    search = al.m.MockSearch(name="test_search_2", samples=samples)
+    search = al.m.MockSearch(name="test_search_2")
 
     result = search.fit(model=model, analysis=analysis_imaging_7x7)
 
@@ -58,9 +52,9 @@ def test__max_log_likelihood_positions_threshold(masked_imaging_7x7):
         ]
     )
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = res.Result(samples=samples, analysis=analysis)
+    result = res.Result(samples_summary=samples_summary, analysis=analysis)
 
     assert result.max_log_likelihood_positions_threshold == pytest.approx(
         0.8309561230, 1.0e-4
@@ -76,9 +70,9 @@ def test__source_plane_light_profile_centre(analysis_imaging_7x7):
 
     tracer = al.Tracer(galaxies=[lens, source])
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = res.Result(samples=samples, analysis=analysis_imaging_7x7)
+    result = res.Result(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     assert result.source_plane_light_profile_centre.in_list == [(1.0, 2.0)]
 
@@ -94,9 +88,9 @@ def test__source_plane_light_profile_centre(analysis_imaging_7x7):
 
     tracer = al.Tracer(galaxies=[lens, source_0, source_1])
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = res.Result(samples=samples, analysis=analysis_imaging_7x7)
+    result = res.Result(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     assert result.source_plane_light_profile_centre.in_list == [(1.0, 2.0)]
 
@@ -110,17 +104,17 @@ def test__source_plane_light_profile_centre(analysis_imaging_7x7):
 
     tracer = al.Tracer(galaxies=[lens, source_0, source_1])
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = res.Result(samples=samples, analysis=analysis_imaging_7x7)
+    result = res.Result(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     assert result.source_plane_light_profile_centre.in_list == [(5.0, 6.0)]
 
     tracer = al.Tracer(galaxies=[al.Galaxy(redshift=0.5)])
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = res.Result(samples=samples, analysis=analysis_imaging_7x7)
+    result = res.Result(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     assert result.source_plane_light_profile_centre == None
 
@@ -137,9 +131,9 @@ def test__source_plane_inversion_centre(analysis_imaging_7x7):
 
     tracer = al.Tracer(galaxies=[lens, source])
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = ResultImaging(samples=samples, analysis=analysis_imaging_7x7)
+    result = ResultImaging(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     assert (
         result.source_plane_inversion_centre.in_list[0]
@@ -155,9 +149,9 @@ def test__source_plane_inversion_centre(analysis_imaging_7x7):
 
     tracer = al.Tracer(galaxies=[lens, source])
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = ResultImaging(samples=samples, analysis=analysis_imaging_7x7)
+    result = ResultImaging(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     assert result.source_plane_inversion_centre == None
 
@@ -166,9 +160,9 @@ def test__source_plane_inversion_centre(analysis_imaging_7x7):
 
     tracer = al.Tracer(galaxies=[lens, source])
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = ResultImaging(samples=samples, analysis=analysis_imaging_7x7)
+    result = ResultImaging(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     assert result.source_plane_inversion_centre == None
 
@@ -189,9 +183,9 @@ def test__source_plane_centre(analysis_imaging_7x7):
 
     tracer = al.Tracer(galaxies=[lens, source])
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = ResultImaging(samples=samples, analysis=analysis_imaging_7x7)
+    result = ResultImaging(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     assert result.source_plane_centre.in_list[0] == pytest.approx(
         (-0.916666, -0.916666), 1.0e-4
@@ -220,9 +214,9 @@ def test__image_plane_multiple_image_positions(analysis_imaging_7x7):
 
     tracer = al.Tracer(galaxies=[lens, source])
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = ResultImaging(samples=samples, analysis=analysis_imaging_7x7)
+    result = ResultImaging(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     multiple_images = result.image_plane_multiple_image_positions
 
@@ -243,9 +237,9 @@ def test__image_plane_multiple_image_positions(analysis_imaging_7x7):
         ]
     )
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = res.Result(samples=samples, analysis=analysis_imaging_7x7)
+    result = res.Result(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     assert result.image_plane_multiple_image_positions.in_list[0][0] == pytest.approx(
         1.0004, 1.0e-2
@@ -268,9 +262,9 @@ def test__positions_threshold_from(analysis_imaging_7x7):
         ]
     )
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = res.Result(samples=samples, analysis=analysis_imaging_7x7)
+    result = res.Result(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     assert result.positions_threshold_from() == pytest.approx(0.000973519, 1.0e-4)
     assert result.positions_threshold_from(factor=5.0) == pytest.approx(
@@ -297,9 +291,9 @@ def test__positions_likelihood_from(analysis_imaging_7x7):
         ]
     )
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=tracer)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
 
-    result = res.Result(samples=samples, analysis=analysis_imaging_7x7)
+    result = res.Result(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     positions_likelihood = result.positions_likelihood_from(
         factor=0.1, minimum_threshold=0.2
@@ -320,7 +314,7 @@ def test__results_include_mask__available_as_property(
     analysis_imaging_7x7, masked_imaging_7x7, samples_with_result
 ):
     result = res.ResultDataset(
-        samples=samples_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis_imaging_7x7,
     )
 
@@ -331,7 +325,7 @@ def test__results_include_positions__available_as_property(
     analysis_imaging_7x7, masked_imaging_7x7, samples_with_result
 ):
     result = res.ResultDataset(
-        samples=samples_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis_imaging_7x7,
     )
 
@@ -346,7 +340,7 @@ def test__results_include_positions__available_as_property(
     )
 
     result = res.ResultDataset(
-        samples=samples_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis,
     )
 
@@ -362,7 +356,7 @@ def test___image_dict(analysis_imaging_7x7):
     instance.galaxies = galaxies
 
     result = ResultImaging(
-        samples=al.m.MockSamples(max_log_likelihood_instance=instance),
+        samples_summary=al.m.MockSamplesSummary(max_log_likelihood_instance=instance),
         analysis=analysis_imaging_7x7,
     )
 

--- a/test_autolens/analysis/test_result.py
+++ b/test_autolens/analysis/test_result.py
@@ -311,7 +311,7 @@ def test__positions_likelihood_from(analysis_imaging_7x7):
 
 
 def test__results_include_mask__available_as_property(
-    analysis_imaging_7x7, masked_imaging_7x7, samples_with_result
+    analysis_imaging_7x7, masked_imaging_7x7, samples_summary_with_result
 ):
     result = res.ResultDataset(
         samples_summary=samples_summary_with_result,
@@ -322,7 +322,7 @@ def test__results_include_mask__available_as_property(
 
 
 def test__results_include_positions__available_as_property(
-    analysis_imaging_7x7, masked_imaging_7x7, samples_with_result
+    analysis_imaging_7x7, masked_imaging_7x7, samples_summary_with_result
 ):
     result = res.ResultDataset(
         samples_summary=samples_summary_with_result,

--- a/test_autolens/conftest.py
+++ b/test_autolens/conftest.py
@@ -391,6 +391,6 @@ def make_include_all():
     return fixtures.make_include_2d_all()
 
 
-@pytest.fixture(name="samples_with_result")
-def make_samples_with_result():
-    return fixtures.make_samples_with_result()
+@pytest.fixture(name="samples_summary_with_result")
+def make_samples_summary_with_result():
+    return fixtures.make_samples_summary_with_result()

--- a/test_autolens/imaging/model/test_analysis_imaging.py
+++ b/test_autolens/imaging/model/test_analysis_imaging.py
@@ -15,17 +15,8 @@ directory = path.dirname(path.realpath(__file__))
 
 
 def test__make_result__result_imaging_is_returned(masked_imaging_7x7):
+
     model = af.Collection(galaxies=af.Collection(galaxy_0=al.Galaxy(redshift=0.5)))
-
-    instance = model.instance_from_prior_medians()
-
-    samples = al.m.MockSamples(
-        model=model,
-        max_log_likelihood_instance=instance,
-        prior_means=[1.0] * model.prior_count
-    )
-
-    search = al.m.MockSearch(name="test_search", samples=samples)
 
     analysis = al.AnalysisImaging(dataset=masked_imaging_7x7)
 
@@ -35,6 +26,8 @@ def test__make_result__result_imaging_is_returned(masked_imaging_7x7):
         pass
 
     analysis.modify_after_fit = modify_after_fit
+
+    search = al.m.MockSearch(name="test_search")
 
     result = search.fit(model=model, analysis=analysis)
 

--- a/test_autolens/imaging/model/test_analysis_imaging.py
+++ b/test_autolens/imaging/model/test_analysis_imaging.py
@@ -1,4 +1,3 @@
-import numpy as np
 from os import path
 import pytest
 

--- a/test_autolens/imaging/model/test_result_imaging.py
+++ b/test_autolens/imaging/model/test_result_imaging.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 import autofit as af
@@ -15,9 +14,9 @@ def test___linear_light_profiles_in_result(analysis_imaging_7x7):
     instance = af.ModelInstance()
     instance.galaxies = galaxies
 
-    samples = al.m.MockSamples(max_log_likelihood_instance=instance)
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=instance)
 
-    result = ResultImaging(samples=samples, analysis=analysis_imaging_7x7)
+    result = ResultImaging(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
     assert not isinstance(
         result.max_log_likelihood_tracer.galaxies[0].bulge,

--- a/test_autolens/interferometer/model/test_analysis_interferometer.py
+++ b/test_autolens/interferometer/model/test_analysis_interferometer.py
@@ -1,5 +1,4 @@
 from os import path
-import numpy as np
 import pytest
 
 import autofit as af
@@ -14,12 +13,6 @@ directory = path.dirname(path.realpath(__file__))
 def test__make_result__result_interferometer_is_returned(interferometer_7):
     model = af.Collection(galaxies=af.Collection(galaxy_0=al.Galaxy(redshift=0.5)))
 
-    instance = model.instance_from_prior_medians()
-
-    samples = al.m.MockSamples(max_log_likelihood_instance=instance)
-
-    search = al.m.MockSearch(name="test_search", samples=samples)
-
     analysis = al.AnalysisInterferometer(dataset=interferometer_7)
 
     def modify_after_fit(
@@ -28,6 +21,8 @@ def test__make_result__result_interferometer_is_returned(interferometer_7):
         pass
 
     analysis.modify_after_fit = modify_after_fit
+
+    search = al.m.MockSearch(name="test_search")
 
     result = search.fit(model=model, analysis=analysis)
 

--- a/test_autolens/quantity/model/test_analysis_quantity.py
+++ b/test_autolens/quantity/model/test_analysis_quantity.py
@@ -7,51 +7,49 @@ from autolens.quantity.model.result import ResultQuantity
 
 directory = path.dirname(path.realpath(__file__))
 
+def test__make_result__result_quantity_is_returned(
+    dataset_quantity_7x7_array_2d
+):
+    model = af.Collection(galaxies=af.Collection(galaxy_0=al.Galaxy(redshift=0.5)))
 
-class TestAnalysisQuantity:
-    def test__make_result__result_quantity_is_returned(
-        self, dataset_quantity_7x7_array_2d
-    ):
-        model = af.Collection(galaxies=af.Collection(galaxy_0=al.Galaxy(redshift=0.5)))
+    analysis = al.AnalysisQuantity(
+        dataset=dataset_quantity_7x7_array_2d, func_str="convergence_2d_from"
+    )
 
-        analysis = al.AnalysisQuantity(
-            dataset=dataset_quantity_7x7_array_2d, func_str="convergence_2d_from"
-        )
+    search = al.m.MockSearch(name="test_search")
 
-        search = al.m.MockSearch(name="test_search")
+    result = search.fit(model=model, analysis=analysis)
 
-        result = search.fit(model=model, analysis=analysis)
+    assert isinstance(result, ResultQuantity)
 
-        assert isinstance(result, ResultQuantity)
+def test__figure_of_merit__matches_correct_fit_given_galaxy_profiles(
+    dataset_quantity_7x7_array_2d
+):
+    galaxy = al.Galaxy(redshift=0.5, light=al.mp.Isothermal(einstein_radius=1.0))
 
-    def test__figure_of_merit__matches_correct_fit_given_galaxy_profiles(
-        self, dataset_quantity_7x7_array_2d
-    ):
-        galaxy = al.Galaxy(redshift=0.5, light=al.mp.Isothermal(einstein_radius=1.0))
+    model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
 
-        model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+    analysis = al.AnalysisQuantity(
+        dataset=dataset_quantity_7x7_array_2d, func_str="convergence_2d_from"
+    )
 
-        analysis = al.AnalysisQuantity(
-            dataset=dataset_quantity_7x7_array_2d, func_str="convergence_2d_from"
-        )
+    instance = model.instance_from_unit_vector([])
+    fit_figure_of_merit = analysis.log_likelihood_function(instance=instance)
 
-        instance = model.instance_from_unit_vector([])
-        fit_figure_of_merit = analysis.log_likelihood_function(instance=instance)
+    tracer = analysis.tracer_via_instance_from(instance=instance)
 
-        tracer = analysis.tracer_via_instance_from(instance=instance)
+    fit = al.FitQuantity(
+        dataset=dataset_quantity_7x7_array_2d,
+        tracer=tracer,
+        func_str="convergence_2d_from",
+    )
 
-        fit = al.FitQuantity(
-            dataset=dataset_quantity_7x7_array_2d,
-            tracer=tracer,
-            func_str="convergence_2d_from",
-        )
+    assert fit.log_likelihood == fit_figure_of_merit
 
-        assert fit.log_likelihood == fit_figure_of_merit
+    fit = al.FitQuantity(
+        dataset=dataset_quantity_7x7_array_2d,
+        tracer=tracer,
+        func_str="potential_2d_from",
+    )
 
-        fit = al.FitQuantity(
-            dataset=dataset_quantity_7x7_array_2d,
-            tracer=tracer,
-            func_str="potential_2d_from",
-        )
-
-        assert fit.log_likelihood != fit_figure_of_merit
+    assert fit.log_likelihood != fit_figure_of_merit


### PR DESCRIPTION
Make it so that all internal results loading use the `SamplesSummary` object instead of the `Samples` object wherever possible.

This has two benefits:

-Loading `samples.csv` /  `search_internal.dill` in order to load results when resuming a model-fit was very slow.

- Recent updates to `output.yaml` mean autofit can now run without outputting a `samples.csv` file or `search_internal.dill` file at all (to save hard disk space).  The samples summary file cannot be customized to not be output, meaning the information for resuming runs is always available.

This is motivated for search chaining prior passing, which by using the `SamplesSummary` resumes previous fits much faster.