### PR TITLE
Feature/adaptive sub 

### DIFF
--- a/autolens/lens/to_inversion.py
+++ b/autolens/lens/to_inversion.py
@@ -215,7 +215,6 @@ class TracerToInversion(ag.AbstractToInversion):
 
     @cached_property
     def mapper_galaxy_dict(self) -> Dict[aa.AbstractMapper, ag.Galaxy]:
-
         if not self.has_mapper:
             return {}
 


### PR DESCRIPTION
Adaptive sub-sampling now works for pixelizations.

This means that instead of a fixed `sub_size` being used for a pixelization, an array with the same dimensions as the mask can be input specifying the `sub_size` in each image pixel.

This means we can assign high `sub_size` values to a source galaxy's brightest regions and low values elsewhere, offering computational speed up.

Template SLaM pipelines using this functionality will be provided after testing.