### PR TITLE
Feature/sub iterate tracer

### DIFF
--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -131,6 +131,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             border_relocator=self.dataset.border_relocator,
         )
 
+
         return TracerToInversion(
             dataset=dataset,
             tracer=self.tracer,
@@ -138,6 +139,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             adapt_images=self.adapt_images,
             settings_inversion=self.settings_inversion,
             preloads=self.preloads,
+            run_time_dict=self.run_time_dict
         )
 
     @cached_property

--- a/autolens/lens/to_inversion.py
+++ b/autolens/lens/to_inversion.py
@@ -109,6 +109,7 @@ class TracerToInversion(ag.AbstractToInversion):
                 sky=self.sky,
                 settings_inversion=self.settings_inversion,
                 adapt_images=self.adapt_images,
+                run_time_dict=self.run_time_dict,
             )
 
             lp_linear_galaxy_dict_of_plane = (
@@ -170,6 +171,7 @@ class TracerToInversion(ag.AbstractToInversion):
                 sky=self.sky,
                 adapt_images=self.adapt_images,
                 settings_inversion=self.settings_inversion,
+                run_time_dict=self.run_time_dict,
             )
 
             image_plane_mesh_grid_list = to_inversion.image_plane_mesh_grid_list
@@ -247,6 +249,7 @@ class TracerToInversion(ag.AbstractToInversion):
                     preloads=self.preloads,
                     adapt_images=self.adapt_images,
                     settings_inversion=self.settings_inversion,
+                    run_time_dict=self.run_time_dict,
                 )
 
                 galaxies_with_pixelization_list = galaxies.galaxies_with_cls_list_from(

--- a/autolens/lens/tracer.py
+++ b/autolens/lens/tracer.py
@@ -415,13 +415,18 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections):
         """
         Returns a list of the 2D images for each plane from a 2D grid of Cartesian (y,x) coordinates.
 
-        The image of each plane is computed by summing the images of all galaxies in that plane. If a plane has no
-        galaxies, or if the galaxies in a plane has no light profiles, a numpy array of zeros is returned.
+        The image of each plane is computed by ray-tracing the grid using te mass profiles of each galaxies and then
+        summing the images of all galaxies in that plane. If a plane has no galaxies, or if the galaxies in a plane
+        has no light profiles, a numpy array of zeros is returned.
 
         For example, if the tracer's planes contain galaxies at redshifts z=0.5, z=1.0 and z=2.0, and the galaxies
         at redshifts z=0.5 and z=1.0 have light and mass profiles, the returned list of images will be the image of the
         galaxies at z=0.5 and z=1.0, where the image at redshift z=1.0 will include the lensing effects of the galaxies
         at z=0.5. The image at redshift z=2.0 will be a numpy array of zeros.
+
+        The `plane_index` input is used to return a specific image of a plane, as opposed to a list of images
+        of all planes. This can save on computational time when only the image of a specific plane is needed,
+        and is used to perform iterative over-sampling calculations.
 
         The images output by this function do not include instrument operations, such as PSF convolution (for imaging
         data) or a Fourier transform (for interferometer data).
@@ -484,6 +489,71 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections):
                 image_2d_list.append(image_2d)
 
         return image_2d_list
+
+    @over_sample
+    def image_2d_of_plane_from(
+            self,
+            grid: aa.type.Grid2DLike,
+            plane_index: int,
+            operated_only: Optional[bool] = None,
+    ) -> aa.Array2D:
+        """
+        Returns a 2D image of an input plane from a 2D grid of Cartesian (y,x) coordinates.
+
+        The image of the plane is computed by ray-tracing the grid using te mass profiles of all galaxies before the
+        input plane and then summing the images of all galaxies in that plane. If a plane has no galaxies, or if the
+        galaxies in a plane, has no light profiles, a numpy array of zeros is returned.
+
+        For example, if the tracer's planes contain galaxies at redshifts z=0.5, z=1.0 and z=2.0, and the galaxies
+        at redshifts z=0.5 and z=1.0 have light and mass profiles, the returned image for `plane_index=1` will be the
+        image of the galaxy at z=1.0, where the image at redshift z=1.0 will include the lensing effects of the
+        galaxies at z=0.5. The image at redshift z=2.0 will be ignored.
+
+        The `plane_index` input specifies which plane the image os returned for. This calculation saves computational
+        time compared to `image_2d_list_from` when only the image of a specific plane is needed. It is also used to
+        perform iterative over-sampling calculations.
+
+        The images output by this function do not include instrument operations, such as PSF convolution (for imaging
+        data) or a Fourier transform (for interferometer data).
+
+        Inherited methods in the `autogalaxy.operate.image` package can apply these operations to the images.
+        These functions may have the `operated_only` input passed to them, which is why this function includes
+        the `operated_only` input.
+
+        If the `operated_only` input is included, the function omits light profiles which are parents of
+        the `LightProfileOperated` object, which signifies that the light profile represents emission that has
+        already had the instrument operations (e.g. PSF convolution, a Fourier transform) applied to it and therefore
+        that operation is not performed again.
+
+        See the `autogalaxy.profiles.light` package for details of how images are computed from a light
+        profile.
+
+        Parameters
+        ----------
+        grid
+            The 2D (y, x) coordinates where values of the image are evaluated.
+        plane_index
+            The plane index of the plane the image is computed.
+        operated_only
+            The returned list from this function contains all light profile images, and they are never operated on
+            (e.g. via the imaging PSF). However, inherited methods in the `autogalaxy.operate.image` package can
+            apply these operations to the images, which may have the `operated_only` input passed to them. This input
+            therefore is used to pass the `operated_only` input to these methods.
+        """
+
+        traced_grid_list = self.traced_grid_2d_list_from(
+            grid=grid, plane_index_limit=plane_index
+        )
+
+        return sum(
+            [
+                galaxy.image_2d_from(
+                    grid=traced_grid_list[plane_index],
+                    operated_only=operated_only,
+                )
+                for galaxy in self.planes[plane_index]
+            ]
+        )
 
     @over_sample
     @aa.grid_dec.to_array

--- a/autolens/lens/tracer.py
+++ b/autolens/lens/tracer.py
@@ -580,9 +580,9 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections):
         galaxies at z=0.5 and z=1.0, where the image at redshift z=1.0 will include the lensing effects of the galaxies
         at z=0.5. The image at redshift z=2.0 will be a numpy array of zeros.
 
-        The `plane_index` input is used to return a specific image of a plane, as opposed to a list of images
-        of all planes. This can save on computational time when only the image of a specific plane is needed,
-        and is used to perform iterative over-sampling calculations.
+        The implementation of this function has to wrap a function in the iterative over sampler which performs the
+        iterative over-sampling calculation. This requires a function to be defined internally in this function
+        which meets the requirements of the over-sample.
 
         The images output by this function do not include instrument operations, such as PSF convolution (for imaging
         data) or a Fourier transform (for interferometer data).
@@ -602,11 +602,13 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections):
         Parameters
         ----------
         grid
+            The 2D (y, x) coordinates where values of the image are evaluated, which has an iterative over-sampling
+            applied to it.
         operated_only
-
-        Returns
-        -------
-
+            The returned list from this function contains all light profile images, and they are never operated on
+            (e.g. via the imaging PSF). However, inherited methods in the `autogalaxy.operate.image` package can
+            apply these operations to the images, which may have the `operated_only` input passed to them. This input
+            therefore is used to pass the `operated_only` input to these methods.
         """
 
         image_2d_list = []

--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -19,7 +19,6 @@ grids of (y,x) Cartesian coordinates (which are used for evaluating light profil
    Mask2D
    Array2D
    Grid2D
-   Grid2DIterate
    Grid2DIrregular
 
 Imaging
@@ -53,6 +52,24 @@ a fast Fourier transform to map data to the uv-plane.
    Visibilities
    TransformerDFT
    TransformerNUFFT
+
+Over Sampling
+-------------
+
+Calculations using grids approximate a 2D line integral of the light in the galaxy which falls in each image-pixel.
+Different over sampling schemes can be used to efficiently approximate this integral and these objects can be
+applied to datasets to apply over sampling to their fit.
+
+.. currentmodule:: autolens
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-class-template.rst
+   :recursive:
+
+   OverSamplingUniform
+   OverSamplingIterate
+
 
 1D Data Structures
 ------------------

--- a/test_autolens/lens/test_tracer.py
+++ b/test_autolens/lens/test_tracer.py
@@ -220,6 +220,7 @@ def test__image_2d_list_from():
     assert image_list[2][0] == pytest.approx(1.8611933, 1.0e-4)
     assert len(image_list) == 3
 
+
 def test__image_2d_of_plane_from():
     g0 = al.Galaxy(redshift=0.5, light_profile=al.lp.Sersic(intensity=1.0))
     g1 = al.Galaxy(redshift=0.5, light_profile=al.lp.Sersic(intensity=2.0))
@@ -227,10 +228,7 @@ def test__image_2d_of_plane_from():
 
     tracer = al.Tracer(galaxies=[g0, g1, g2])
 
-    image = tracer.image_2d_of_plane_from(
-        grid=grid_simple,
-        plane_index=0
-    )
+    image = tracer.image_2d_of_plane_from(grid=grid_simple, plane_index=0)
 
     assert image == pytest.approx(0.30276535, 1.0e-4)
 
@@ -248,24 +246,15 @@ def test__image_2d_of_plane_from():
 
     tracer = al.Tracer(galaxies=[g0, g1, g2])
 
-    image = tracer.image_2d_of_plane_from(
-        grid=grid_simple,
-        plane_index=0
-    )
+    image = tracer.image_2d_of_plane_from(grid=grid_simple, plane_index=0)
 
     assert image == pytest.approx(0.0504608, 1.0e-4)
 
-    image = tracer.image_2d_of_plane_from(
-        grid=grid_simple,
-        plane_index=1
-    )
+    image = tracer.image_2d_of_plane_from(grid=grid_simple, plane_index=1)
 
     assert image == pytest.approx(0.2517025, 1.0e-4)
 
-    image = tracer.image_2d_of_plane_from(
-        grid=grid_simple,
-        plane_index=2
-    )
+    image = tracer.image_2d_of_plane_from(grid=grid_simple, plane_index=2)
 
     assert image == pytest.approx(1.8611933, 1.0e-4)
 
@@ -295,26 +284,21 @@ def test__image_2d_list_from__adaptive_iterate_sub_grid():
     g2 = al.Galaxy(redshift=2.0, light_profile=al.lp.Sersic(intensity=3.0))
 
     tracer = al.Tracer(galaxies=[g0, g1, g2])
-    
-    def image_2d_list_from_sub_size(sub_size):
 
+    def image_2d_list_from_sub_size(sub_size):
         grid = al.Grid2D.from_mask(
             mask=mask, over_sampling=al.OverSamplingUniform(sub_size=sub_size)
         )
-    
+
         grid_oversampled = grid.over_sampler.over_sampled_grid
         traced_grid_list = tracer.traced_grid_2d_list_from(grid=grid_oversampled)
-    
+
         image_g0 = g0.image_2d_from(grid=grid)
         image_g1_oversampled = g1.image_2d_from(grid=traced_grid_list[1])
-        image_g1 = grid.over_sampler.binned_array_2d_from(
-            array=image_g1_oversampled
-        )
-    
+        image_g1 = grid.over_sampler.binned_array_2d_from(array=image_g1_oversampled)
+
         image_g2_oversampled = g2.image_2d_from(grid=traced_grid_list[2])
-        image_g2 = grid.over_sampler.binned_array_2d_from(
-            array=image_g2_oversampled
-        )
+        image_g2 = grid.over_sampler.binned_array_2d_from(array=image_g2_oversampled)
 
         return [image_g0, image_g1, image_g2]
 

--- a/test_autolens/lens/test_tracer.py
+++ b/test_autolens/lens/test_tracer.py
@@ -220,6 +220,55 @@ def test__image_2d_list_from():
     assert image_list[2][0] == pytest.approx(1.8611933, 1.0e-4)
     assert len(image_list) == 3
 
+def test__image_2d_of_plane_from():
+    g0 = al.Galaxy(redshift=0.5, light_profile=al.lp.Sersic(intensity=1.0))
+    g1 = al.Galaxy(redshift=0.5, light_profile=al.lp.Sersic(intensity=2.0))
+    g2 = al.Galaxy(redshift=0.5, light_profile=al.lp.Sersic(intensity=3.0))
+
+    tracer = al.Tracer(galaxies=[g0, g1, g2])
+
+    image = tracer.image_2d_of_plane_from(
+        grid=grid_simple,
+        plane_index=0
+    )
+
+    assert image == pytest.approx(0.30276535, 1.0e-4)
+
+    g0 = al.Galaxy(
+        redshift=0.5,
+        light_profile=al.lp.Sersic(intensity=1.0),
+        mass_profile=al.mp.IsothermalSph(einstein_radius=1.0),
+    )
+    g1 = al.Galaxy(
+        redshift=1.0,
+        light_profile=al.lp.Sersic(intensity=2.0),
+        mass_profile=al.mp.IsothermalSph(einstein_radius=2.0),
+    )
+    g2 = al.Galaxy(redshift=2.0, light_profile=al.lp.Sersic(intensity=3.0))
+
+    tracer = al.Tracer(galaxies=[g0, g1, g2])
+
+    image = tracer.image_2d_of_plane_from(
+        grid=grid_simple,
+        plane_index=0
+    )
+
+    assert image == pytest.approx(0.0504608, 1.0e-4)
+
+    image = tracer.image_2d_of_plane_from(
+        grid=grid_simple,
+        plane_index=1
+    )
+
+    assert image == pytest.approx(0.2517025, 1.0e-4)
+
+    image = tracer.image_2d_of_plane_from(
+        grid=grid_simple,
+        plane_index=2
+    )
+
+    assert image == pytest.approx(1.8611933, 1.0e-4)
+
 
 def test__image_2d_list_from__adaptive_iterate_sub_grid():
     mask = al.Mask2D(
@@ -266,7 +315,7 @@ def test__image_2d_list_from__adaptive_iterate_sub_grid():
         over_sampling=al.OverSamplingIterate(fractional_accuracy=1.0, sub_steps=[2, 4]),
     )
 
-    image_2d_list = tracer.image_2d_list_from(grid=grid_sub_4)
+    image_2d_list = tracer.image_2d_list_from(grid=grid_iterate)
 
     assert image_2d_list[0] == pytest.approx(image_g0_sub_4, 1.0e-4)
     assert image_2d_list[1] == pytest.approx(image_g1_sub_4, 1.0e-4)


### PR DESCRIPTION
`image_2d_from` and `image_2d_list_from` methods in a `Tracer` now perform calculations with iteratively increasing `sub_size` values until a threshold accuracy is met, if an `OverSamplingIterate` object is used with the grid.

For example:

```
    g0 = al.Galaxy(
        redshift=0.5,
        light_profile=al.lp.Sersic(intensity=1.0),
        mass_profile=al.mp.IsothermalSph(einstein_radius=1.0),
    )
    g1 = al.Galaxy(
        redshift=1.0,
        light_profile=al.lp.Sersic(intensity=2.0),
        mass_profile=al.mp.IsothermalSph(einstein_radius=2.0),
    )
    g2 = al.Galaxy(redshift=2.0, light_profile=al.lp.Sersic(intensity=3.0))

    tracer = al.Tracer(galaxies=[g0, g1, g2])

    grid_iterate = al.Grid2D.from_mask(
        mask=mask,
        over_sampling=al.OverSamplingIterate(fractional_accuracy=0.7, sub_steps=[2, 4]),
    )

    image_2d_list = tracer.image_2d_list_from(grid=grid_iterate)
```