### PR TITLE
Feature/data offset

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -5,6 +5,7 @@ from autoarray.dataset.imaging.dataset import Imaging
 from autoarray.dataset.interferometer.dataset import (
     Interferometer,
 )
+from autoarray.dataset.model import DatasetModel
 from autoarray.mask.mask_1d import Mask1D
 from autoarray.mask.mask_2d import Mask2D
 from autoarray.operators.convolver import Convolver

--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -5,7 +5,7 @@ from autoarray.dataset.imaging.dataset import Imaging
 from autoarray.dataset.interferometer.dataset import (
     Interferometer,
 )
-from autoarray.dataset.model import DatasetModel
+from autoarray.dataset.dataset_model import DatasetModel
 from autoarray.mask.mask_1d import Mask1D
 from autoarray.mask.mask_2d import Mask2D
 from autoarray.operators.convolver import Convolver

--- a/autolens/aggregator/fit_imaging.py
+++ b/autolens/aggregator/fit_imaging.py
@@ -72,7 +72,11 @@ def _fit_imaging_from(
     fit_dataset_list = []
 
     for dataset, tracer, dataset_model, adapt_images, mesh_grids_of_planes in zip(
-        dataset_list, tracer_list, dataset_model_list, adapt_images_list, mesh_grids_of_planes_list
+        dataset_list,
+        tracer_list,
+        dataset_model_list,
+        adapt_images_list,
+        mesh_grids_of_planes_list,
     ):
         preloads = agg_util.preloads_from(
             preloads_cls=Preloads,

--- a/autolens/aggregator/fit_imaging.py
+++ b/autolens/aggregator/fit_imaging.py
@@ -7,6 +7,7 @@ from autolens.imaging.fit_imaging import FitImaging
 from autolens.analysis.preloads import Preloads
 
 from autogalaxy.aggregator.imaging import _imaging_from
+from autogalaxy.aggregator.dataset_model import _dataset_model_from
 from autogalaxy.aggregator import agg_util
 
 from autolens.aggregator.tracer import _tracer_from
@@ -58,6 +59,8 @@ def _fit_imaging_from(
 
     tracer_list = _tracer_from(fit=fit, instance=instance)
 
+    dataset_model_list = _dataset_model_from(fit=fit, instance=instance)
+
     adapt_images_list = agg_util.adapt_images_from(fit=fit)
 
     settings_inversion = settings_inversion or fit.value(name="settings_inversion")
@@ -68,8 +71,8 @@ def _fit_imaging_from(
 
     fit_dataset_list = []
 
-    for dataset, tracer, adapt_images, mesh_grids_of_planes in zip(
-        dataset_list, tracer_list, adapt_images_list, mesh_grids_of_planes_list
+    for dataset, tracer, dataset_model, adapt_images, mesh_grids_of_planes in zip(
+        dataset_list, tracer_list, dataset_model_list, adapt_images_list, mesh_grids_of_planes_list
     ):
         preloads = agg_util.preloads_from(
             preloads_cls=Preloads,
@@ -82,6 +85,7 @@ def _fit_imaging_from(
             FitImaging(
                 dataset=dataset,
                 tracer=tracer,
+                dataset_model=dataset_model,
                 adapt_images=adapt_images,
                 settings_inversion=settings_inversion,
                 preloads=preloads,

--- a/autolens/aggregator/fit_interferometer.py
+++ b/autolens/aggregator/fit_interferometer.py
@@ -4,6 +4,7 @@ import autofit as af
 import autoarray as aa
 
 from autogalaxy.aggregator.interferometer import _interferometer_from
+from autogalaxy.aggregator.dataset_model import _dataset_model_from
 
 from autolens.interferometer.fit_interferometer import FitInterferometer
 from autolens.analysis.preloads import Preloads
@@ -60,6 +61,7 @@ def _fit_interferometer_from(
         real_space_mask=real_space_mask,
     )
     tracer_list = _tracer_from(fit=fit, instance=instance)
+    dataset_model_list = _dataset_model_from(fit=fit, instance=instance)
 
     adapt_images_list = agg_util.adapt_images_from(fit=fit)
 
@@ -71,8 +73,8 @@ def _fit_interferometer_from(
 
     fit_dataset_list = []
 
-    for dataset, tracer, adapt_images, mesh_grids_of_planes in zip(
-        dataset_list, tracer_list, adapt_images_list, mesh_grids_of_planes_list
+    for dataset, tracer, dataset_model, adapt_images, mesh_grids_of_planes in zip(
+        dataset_list, tracer_list, dataset_model_list, adapt_images_list, mesh_grids_of_planes_list
     ):
         preloads = agg_util.preloads_from(
             preloads_cls=Preloads,
@@ -85,6 +87,7 @@ def _fit_interferometer_from(
             FitInterferometer(
                 dataset=dataset,
                 tracer=tracer,
+                dataset_model=dataset_model,
                 adapt_images=adapt_images,
                 settings_inversion=settings_inversion,
                 preloads=preloads,

--- a/autolens/aggregator/fit_interferometer.py
+++ b/autolens/aggregator/fit_interferometer.py
@@ -74,7 +74,11 @@ def _fit_interferometer_from(
     fit_dataset_list = []
 
     for dataset, tracer, dataset_model, adapt_images, mesh_grids_of_planes in zip(
-        dataset_list, tracer_list, dataset_model_list, adapt_images_list, mesh_grids_of_planes_list
+        dataset_list,
+        tracer_list,
+        dataset_model_list,
+        adapt_images_list,
+        mesh_grids_of_planes_list,
     ):
         preloads = agg_util.preloads_from(
             preloads_cls=Preloads,

--- a/autolens/analysis/preloads.py
+++ b/autolens/analysis/preloads.py
@@ -159,11 +159,11 @@ class Preloads(ag.Preloads):
         self.traced_grids_of_planes_for_inversion = None
 
         traced_grids_of_planes_0 = fit_0.tracer.traced_grid_2d_list_from(
-            grid=fit_0.dataset.grid_pixelization
+            grid=fit_0.grid_pixelization
         )
 
         traced_grids_of_planes_1 = fit_1.tracer.traced_grid_2d_list_from(
-            grid=fit_1.dataset.grid_pixelization
+            grid=fit_1.grid_pixelization
         )
 
         if traced_grids_of_planes_0[-1] is not None:

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -96,9 +96,9 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         if self.preloads.blurred_image is None:
 
             return self.tracer.blurred_image_2d_from(
-                grid=self.dataset.grid,
+                grid=self.grid,
                 convolver=self.dataset.convolver,
-                blurring_grid=self.dataset.blurring_grid,
+                blurring_grid=self.blurring_grid,
             )
 
         return self.preloads.blurred_image
@@ -120,8 +120,8 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             convolver=self.dataset.convolver,
             w_tilde=self.w_tilde,
             grid=self.grid,
-            grid_pixelization=self.dataset.grid_pixelization,
-            blurring_grid=self.dataset.blurring_grid,
+            grid_pixelization=self.grid_pixelization,
+            blurring_grid=self.blurring_grid,
             border_relocator=self.dataset.border_relocator,
         )
 
@@ -167,10 +167,6 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         return self.blurred_image
 
     @property
-    def grid(self) -> aa.type.Grid2DLike:
-        return self.dataset.grid
-
-    @property
     def galaxy_model_image_dict(self) -> Dict[ag.Galaxy, np.ndarray]:
         """
         A dictionary which associates every galaxy in the tracer with its `model_image`.
@@ -188,7 +184,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         galaxy_blurred_image_2d_dict = self.tracer.galaxy_blurred_image_2d_dict_from(
             grid=self.grid,
             convolver=self.dataset.convolver,
-            blurring_grid=self.dataset.blurring_grid,
+            blurring_grid=self.blurring_grid,
         )
 
         galaxy_linear_obj_image_dict = self.galaxy_linear_obj_data_dict_from(
@@ -257,7 +253,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
 
         model_images_of_planes_list = [
             aa.Array2D(
-            values=np.zeros(self.dataset.grid.shape_slim), mask=self.dataset.mask
+            values=np.zeros(self.grid.shape_slim), mask=self.dataset.mask
             )
             for i in range(self.tracer.total_planes)
         ]

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -95,16 +95,11 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
 
         if self.preloads.blurred_image is None:
 
-            if isinstance(self.sky, ag.lp.Sky):
-                image = self.sky.image_2d_from(grid=self.dataset.grid)
-            else:
-                image = np.zeros(self.dataset.shape_slim)
-
             return self.tracer.blurred_image_2d_from(
                 grid=self.dataset.grid,
                 convolver=self.dataset.convolver,
                 blurring_grid=self.dataset.blurring_grid,
-            ) + image
+            )
 
         return self.preloads.blurred_image
 
@@ -114,7 +109,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         Returns the dataset's image with all blurred light profile images in the fit's tracer subtracted.
         """
 
-        return self.image - self.blurred_image
+        return self.data - self.blurred_image
 
     @property
     def tracer_to_inversion(self) -> TracerToInversion:
@@ -134,7 +129,6 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         return TracerToInversion(
             dataset=dataset,
             tracer=self.tracer,
-            sky=self.sky,
             adapt_images=self.adapt_images,
             settings_inversion=self.settings_inversion,
             preloads=self.preloads,
@@ -383,7 +377,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         return FitImaging(
             dataset=self.dataset,
             tracer=self.tracer,
-            sky=self.sky,
+            dataset_model=self.dataset_model,
             adapt_images=self.adapt_images,
             settings_inversion=settings_inversion,
             preloads=preloads,

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -295,7 +295,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
                 if i != galaxy_index
             ]
 
-            subtracted_image = self.image - sum(other_planes_model_images)
+            subtracted_image = self.data - sum(other_planes_model_images)
 
             subtracted_images_of_planes_list.append(subtracted_image)
 

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -21,7 +21,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         self,
         dataset: aa.Imaging,
         tracer: Tracer,
-        sky: Optional[ag.LightProfile] = None,
+        dataset_model : Optional[aa.DatasetModel] = None,
         adapt_images: Optional[ag.AdaptImages] = None,
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads: Preloads = Preloads(),
@@ -57,8 +57,8 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             The imaging dataset which is fitted by the galaxies in the tracer.
         tracer
             The tracer of galaxies whose light profile images are used to fit the imaging data.
-        sky
-            Model component used to represent the background sky emission in an image (e.g. a `Sky` light profile).
+        dataset_model
+            Attributes which allow for parts of a dataset to be treated as a model (e.g. the background sky level).
         adapt_images
             Contains the adapt-images which are used to make a pixelization's mesh and regularization adapt to the
             reconstructed galaxy's morphology.
@@ -72,12 +72,11 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             decorator take to run.
         """
 
-        super().__init__(dataset=dataset, run_time_dict=run_time_dict)
+        super().__init__(dataset=dataset, dataset_model=dataset_model, run_time_dict=run_time_dict)
         AbstractFitInversion.__init__(
-            self=self, model_obj=tracer, sky=sky, settings_inversion=settings_inversion
+            self=self, model_obj=tracer, settings_inversion=settings_inversion
         )
 
-        self.sky = sky
         self.tracer = tracer
 
         self.adapt_images = adapt_images

--- a/autolens/imaging/mock/mock_fit_imaging.py
+++ b/autolens/imaging/mock/mock_fit_imaging.py
@@ -23,8 +23,16 @@ class MockFitImaging(aa.m.MockFitImaging):
             blurred_image=blurred_image,
         )
 
+        self._grid = grid
         self.tracer = tracer
-        self.grid = grid
+
+    @property
+    def grid(self):
+
+        if self._grid is not None:
+            return self._grid
+
+        return super().grid
 
     @property
     def tracer_to_inversion(self) -> MockTracerToInversion:

--- a/autolens/imaging/model/analysis.py
+++ b/autolens/imaging/model/analysis.py
@@ -159,7 +159,7 @@ class AnalysisImaging(AnalysisDataset):
             instance=instance, run_time_dict=run_time_dict
         )
 
-        sky = self.sky_via_instance_from(instance=instance)
+        dataset_model = self.dataset_model_via_instance_from(instance=instance)
 
         adapt_images = self.adapt_images_via_instance_from(instance=instance)
 
@@ -168,7 +168,7 @@ class AnalysisImaging(AnalysisDataset):
         return FitImaging(
             dataset=self.dataset,
             tracer=tracer,
-            sky=sky,
+            dataset_model=dataset_model,
             adapt_images=adapt_images,
             settings_inversion=self.settings_inversion,
             preloads=preloads,

--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -85,7 +85,9 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
 
         self.run_time_dict = run_time_dict
 
-        super().__init__(dataset=dataset, dataset_model=dataset_model, run_time_dict=run_time_dict)
+        super().__init__(
+            dataset=dataset, dataset_model=dataset_model, run_time_dict=run_time_dict
+        )
         AbstractFitInversion.__init__(
             self=self, model_obj=tracer, settings_inversion=settings_inversion
         )

--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -84,7 +84,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
 
         super().__init__(dataset=dataset, run_time_dict=run_time_dict)
         AbstractFitInversion.__init__(
-            self=self, model_obj=tracer, sky=None, settings_inversion=settings_inversion
+            self=self, model_obj=tracer, settings_inversion=settings_inversion
         )
 
     @property
@@ -274,8 +274,9 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
             settings_inversion = self.settings_inversion
 
         return FitInterferometer(
-            dataset=self.interferometer,
+            dataset=self.dataset,
             tracer=self.tracer,
+            dataset_model=self.dataset_model,
             adapt_images=self.adapt_images,
             settings_inversion=settings_inversion,
             preloads=preloads,

--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -97,7 +97,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         transform to the sum of light profile images.
         """
         return self.tracer.visibilities_from(
-            grid=self.dataset.grid, transformer=self.dataset.transformer
+            grid=self.grid, transformer=self.dataset.transformer
         )
 
     @property
@@ -116,7 +116,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
             transformer=self.dataset.transformer,
             w_tilde=self.w_tilde,
             grid=self.grid,
-            grid_pixelization=self.dataset.grid_pixelization,
+            grid_pixelization=self.grid_pixelization,
             border_relocator=self.dataset.border_relocator,
         )
 
@@ -158,10 +158,6 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         return self.profile_visibilities
 
     @property
-    def grid(self) -> aa.type.Grid2DLike:
-        return self.dataset.grid
-
-    @property
     def galaxy_model_image_dict(self) -> Dict[ag.Galaxy, np.ndarray]:
         """
         A dictionary which associates every galaxy in the tracer with its `image`.
@@ -196,7 +192,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
           are solved for first via the inversion.
         """
         galaxy_model_visibilities_dict = self.tracer.galaxy_visibilities_dict_from(
-            grid=self.dataset.grid, transformer=self.dataset.transformer
+            grid=self.grid, transformer=self.dataset.transformer
         )
 
         galaxy_linear_obj_visibilities_dict = self.galaxy_linear_obj_data_dict_from(

--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -222,7 +222,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         galaxy_model_visibilities_dict = self.galaxy_model_visibilities_dict
 
         model_visibilities_of_planes_list = [
-            aa.Visibilities.zeros(shape_slim=(self.dataset.visibilities.shape_slim,))
+            aa.Visibilities.zeros(shape_slim=(self.dataset.data.shape_slim,))
             for i in range(self.tracer.total_planes)
         ]
 

--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -18,6 +18,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         self,
         dataset: aa.Interferometer,
         tracer: Tracer,
+        dataset_model: Optional[aa.DatasetModel] = None,
         adapt_images: Optional[ag.AdaptImages] = None,
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads: Preloads = Preloads(),
@@ -54,6 +55,8 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
             The interforometer dataset which is fitted by the galaxies in the tracer.
         tracer
             The tracer of galaxies whose light profile images are used to fit the interferometer data.
+        dataset_model
+            Attributes which allow for parts of a dataset to be treated as a model (e.g. the background sky level).
         adapt_images
             Contains the adapt-images which are used to make a pixelization's mesh and regularization adapt to the
             reconstructed galaxy's morphology.
@@ -82,7 +85,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
 
         self.run_time_dict = run_time_dict
 
-        super().__init__(dataset=dataset, run_time_dict=run_time_dict)
+        super().__init__(dataset=dataset, dataset_model=dataset_model, run_time_dict=run_time_dict)
         AbstractFitInversion.__init__(
             self=self, model_obj=tracer, settings_inversion=settings_inversion
         )
@@ -103,7 +106,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         Returns the interferometer dataset's visibilities with all transformed light profile images in the fit's
         tracer subtracted.
         """
-        return self.visibilities - self.profile_visibilities
+        return self.data - self.profile_visibilities
 
     @property
     def tracer_to_inversion(self) -> TracerToInversion:

--- a/autolens/interferometer/model/analysis.py
+++ b/autolens/interferometer/model/analysis.py
@@ -313,7 +313,7 @@ class AnalysisInterferometer(AnalysisDataset):
             instance=instance,
         )
 
-        info_dict["number_of_visibilities"] = self.dataset.visibilities.shape[0]
+        info_dict["number_of_visibilities"] = self.dataset.data.shape[0]
         info_dict["transformer_cls"] = self.dataset.transformer.__class__.__name__
 
         self.output_profiling_info(

--- a/autolens/interferometer/plot/fit_interferometer_plotters.py
+++ b/autolens/interferometer/plot/fit_interferometer_plotters.py
@@ -99,7 +99,7 @@ class FitInterferometerPlotter(Plotter):
         """
         return TracerPlotter(
             tracer=self.tracer,
-            grid=self.fit.dataset.grid,
+            grid=self.fit.grid,
             mat_plot_2d=self.mat_plot_2d,
             visuals_2d=self.visuals_2d,
             include_2d=self.include_2d,

--- a/autolens/lens/to_inversion.py
+++ b/autolens/lens/to_inversion.py
@@ -16,7 +16,6 @@ class TracerToInversion(ag.AbstractToInversion):
         self,
         dataset: Optional[Union[aa.Imaging, aa.Interferometer, aa.DatasetInterface]],
         tracer,
-        sky: Optional[Basis] = None,
         adapt_images: Optional[ag.AdaptImages] = None,
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads=Preloads(),
@@ -26,7 +25,6 @@ class TracerToInversion(ag.AbstractToInversion):
 
         super().__init__(
             dataset=dataset,
-            sky=sky,
             adapt_images=adapt_images,
             settings_inversion=settings_inversion,
             preloads=preloads,
@@ -106,7 +104,6 @@ class TracerToInversion(ag.AbstractToInversion):
             galaxies_to_inversion = ag.GalaxiesToInversion(
                 dataset=dataset,
                 galaxies=galaxies,
-                sky=self.sky,
                 settings_inversion=self.settings_inversion,
                 adapt_images=self.adapt_images,
                 run_time_dict=self.run_time_dict,
@@ -168,7 +165,6 @@ class TracerToInversion(ag.AbstractToInversion):
             to_inversion = ag.GalaxiesToInversion(
                 dataset=self.dataset,
                 galaxies=galaxies,
-                sky=self.sky,
                 adapt_images=self.adapt_images,
                 settings_inversion=self.settings_inversion,
                 run_time_dict=self.run_time_dict,
@@ -245,7 +241,6 @@ class TracerToInversion(ag.AbstractToInversion):
                 to_inversion = ag.GalaxiesToInversion(
                     dataset=self.dataset,
                     galaxies=galaxies,
-                    sky=self.sky,
                     preloads=self.preloads,
                     adapt_images=self.adapt_images,
                     settings_inversion=self.settings_inversion,

--- a/autolens/point/fit_point/positions_image.py
+++ b/autolens/point/fit_point/positions_image.py
@@ -1,11 +1,8 @@
-from functools import partial
 from typing import Optional
 
 import autoarray as aa
 import autogalaxy as ag
 
-from autolens.point.point_dataset import PointDict
-from autolens.point.point_dataset import PointDataset
 from autolens.point.point_solver import PointSolver
 from autolens.lens.tracer import Tracer
 

--- a/test_autolens/aggregator/conftest.py
+++ b/test_autolens/aggregator/conftest.py
@@ -56,16 +56,17 @@ def aggregator_from(database_file, analysis, model, samples):
 
 @pytest.fixture(name="model")
 def make_model():
-
     dataset_model = af.Model(al.DatasetModel)
-    dataset_model.background_sky_level = af.UniformPrior(lower_limit=0.5, upper_limit=1.5)
+    dataset_model.background_sky_level = af.UniformPrior(
+        lower_limit=0.5, upper_limit=1.5
+    )
 
     return af.Collection(
         dataset_model=dataset_model,
         galaxies=af.Collection(
             lens=af.Model(al.Galaxy, redshift=0.5, light=al.lp.Sersic),
             source=af.Model(al.Galaxy, redshift=1.0, light=al.lp.Sersic),
-        )
+        ),
     )
 
 

--- a/test_autolens/aggregator/conftest.py
+++ b/test_autolens/aggregator/conftest.py
@@ -56,7 +56,12 @@ def aggregator_from(database_file, analysis, model, samples):
 
 @pytest.fixture(name="model")
 def make_model():
+
+    dataset_model = af.Model(al.DatasetModel)
+    dataset_model.background_sky_level = af.UniformPrior(lower_limit=0.5, upper_limit=1.5)
+
     return af.Collection(
+        dataset_model=dataset_model,
         galaxies=af.Collection(
             lens=af.Model(al.Galaxy, redshift=0.5, light=al.lp.Sersic),
             source=af.Model(al.Galaxy, redshift=1.0, light=al.lp.Sersic),

--- a/test_autolens/aggregator/test_aggregator_fit_imaging.py
+++ b/test_autolens/aggregator/test_aggregator_fit_imaging.py
@@ -28,6 +28,8 @@ def test__fit_imaging_randomly_drawn_via_pdf_gen_from(
             assert fit_list[0].tracer.galaxies[0].light.centre == (10.0, 10.0)
             assert fit_list[0].tracer.galaxies[1].redshift == 1.0
 
+            assert fit_list[0].dataset_model.background_sky_level == 10.0
+
     assert i == 2
 
     clean(database_file=database_file)

--- a/test_autolens/aggregator/test_aggregator_fit_interferometer.py
+++ b/test_autolens/aggregator/test_aggregator_fit_interferometer.py
@@ -28,6 +28,8 @@ def test__fit_interferometer_randomly_drawn_via_pdf_gen_from(
             assert fit_list[0].tracer.galaxies[0].light.centre == (10.0, 10.0)
             assert fit_list[0].tracer.galaxies[1].redshift == 1.0
 
+            assert fit_list[0].dataset_model.background_sky_level == 10.0
+
     assert i == 2
 
     clean(database_file=database_file)

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -492,6 +492,27 @@ def test__fit__model_dataset__grid_offset__handles_special_behaviour(masked_imag
 
     assert fit.figure_of_merit == pytest.approx(-2849711.5317237, 1.0e-4)
 
+    g0_linear = al.Galaxy(
+        redshift=0.5,
+        bulge=al.lp_linear.Sersic(centre=(-1.0, -2.0), sersic_index=1.0),
+        disk=al.lp_linear.Sersic(centre=(-1.0, -2.0), sersic_index=4.0),
+        mass_profile=al.mp.IsothermalSph(centre=(-1.0, -2.0), einstein_radius=1.0),
+    )
+
+    pixelization = al.Pixelization(
+        mesh=al.mesh.Rectangular(shape=(3, 3)),
+        regularization=al.reg.Constant(coefficient=1.0),
+    )
+
+    galaxy_pix = al.Galaxy(redshift=1.0, pixelization=pixelization)
+
+    tracer = al.Tracer(galaxies=[g0_linear, galaxy_pix])
+
+    fit = al.FitImaging(dataset=masked_imaging_7x7, tracer=tracer,
+                        dataset_model=al.DatasetModel(grid_offset=(1.0, 2.0))
+                        )
+    assert fit.figure_of_merit == pytest.approx(-22.79906, 1.0e-4)
+
 
 def test__galaxy_model_image_dict(masked_imaging_7x7):
 

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -461,41 +461,10 @@ def test__fit__sky___handles_special_behaviour(masked_imaging_7x7):
     tracer = al.Tracer(galaxies=[g0, g1])
 
     fit = al.FitImaging(
-        dataset=masked_imaging_7x7,
-        tracer=tracer,
-        sky=al.lp_linear.Sky(),
-        settings_inversion=al.SettingsInversion(use_positive_only_solver=False),
+        dataset=masked_imaging_7x7, tracer=tracer, dataset_model=al.DatasetModel(background_sky_level=5.0)
     )
 
-    assert fit.perform_inversion is True
-    assert fit.figure_of_merit == pytest.approx(-733125.35694344, 1.0e-4)
-
-    sky = fit.sky_linear_light_profiles_to_light_profiles
-
-    assert sky.light_profile_list[0].intensity == pytest.approx(-737.44550397, 1.0e-4)
-    assert sky.light_profile_list[1].intensity == pytest.approx(737.44550397, 1.0e-4)
-
-    fit = al.FitImaging(
-        dataset=masked_imaging_7x7,
-        tracer=tracer,
-        sky=al.lp_linear.Sky(),
-        settings_inversion=al.SettingsInversion(use_positive_only_solver=True),
-    )
-
-    assert fit.perform_inversion is True
-    assert fit.figure_of_merit == pytest.approx(-733125.3569434, 1.0e-4)
-
-    sky = fit.sky_linear_light_profiles_to_light_profiles
-
-    assert sky.light_profile_list[0].intensity == pytest.approx(0.0, 1.0e-4)
-    assert sky.light_profile_list[1].intensity == pytest.approx(1474.891048, 1.0e-4)
-
-    fit = al.FitImaging(
-        dataset=masked_imaging_7x7, tracer=tracer, sky=al.lp.Sky(intensity=-99.0)
-    )
-
-    assert fit.perform_inversion is False
-    assert fit.figure_of_merit == pytest.approx(-2862836.077500, 1.0e-4)
+    assert fit.figure_of_merit == pytest.approx(-3196962.5844406, 1.0e-4)
 
 
 def test__galaxy_model_image_dict(masked_imaging_7x7):

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -17,14 +17,14 @@ def test__model_image__with_and_without_psf_blurring(
 
     fit = al.FitImaging(dataset=masked_imaging_7x7_no_blur, tracer=tracer)
 
-    assert fit.model_image.slim == pytest.approx(
+    assert fit.model_data.slim == pytest.approx(
         np.array([2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]), 1.0e-4
     )
     assert fit.log_likelihood == pytest.approx(-14.6337, 1.0e-4)
 
     fit = al.FitImaging(dataset=masked_imaging_7x7, tracer=tracer)
 
-    assert fit.model_image.slim == pytest.approx(
+    assert fit.model_data.slim == pytest.approx(
         np.array([1.33, 1.16, 1.0, 1.16, 1.0, 1.0, 1.0, 1.0, 1.0]), 1.0e-1
     )
     assert fit.log_likelihood == pytest.approx(-14.52960, 1.0e-4)
@@ -497,7 +497,7 @@ def test__galaxy_model_image_dict(masked_imaging_7x7):
     )
     assert (fit.galaxy_model_image_dict[g2] == np.zeros(9)).all()
 
-    assert fit.model_image.native == pytest.approx(
+    assert fit.model_data.native == pytest.approx(
         fit.galaxy_model_image_dict[g0].native + fit.galaxy_model_image_dict[g1].native,
         1.0e-4,
     )
@@ -523,7 +523,7 @@ def test__galaxy_model_image_dict(masked_imaging_7x7):
     )
     assert (fit.galaxy_model_image_dict[g2] == np.zeros(9)).all()
 
-    assert fit.model_image == pytest.approx(
+    assert fit.model_data == pytest.approx(
         fit.galaxy_model_image_dict[g0_linear] + fit.galaxy_model_image_dict[g1_linear],
         1.0e-4,
     )
@@ -550,7 +550,7 @@ def test__galaxy_model_image_dict(masked_imaging_7x7):
         1.259965886, 1.0e-4
     )
 
-    assert fit.model_image == pytest.approx(
+    assert fit.model_data == pytest.approx(
         fit.galaxy_model_image_dict[galaxy_pix_0], 1.0e-4
     )
 

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -467,6 +467,32 @@ def test__fit__sky___handles_special_behaviour(masked_imaging_7x7):
     assert fit.figure_of_merit == pytest.approx(-3196962.5844406, 1.0e-4)
 
 
+def test__fit__model_dataset__grid_offset__handles_special_behaviour(masked_imaging_7x7):
+
+    # Numerical value changes slightly due to prevision in grid values
+
+    g0 = al.Galaxy(
+        redshift=0.5,
+        bulge=al.lp.Sersic(centre=(-1.0, -2.0), intensity=1.0),
+        disk=al.lp.Sersic(centre=(-1.0, -2.0), intensity=2.0),
+        mass_profile=al.mp.IsothermalSph(centre=(-1.0, -2.0), einstein_radius=1.0),
+    )
+
+    g1 = al.Galaxy(redshift=1.0,
+                   bulge=al.lp.Sersic(centre=(-1.0, -2.0), intensity=1.0)
+                   )
+
+    tracer = al.Tracer(galaxies=[g0, g1])
+
+    fit = al.FitImaging(
+        dataset=masked_imaging_7x7,
+        tracer=tracer,
+        dataset_model=al.DatasetModel(grid_offset=(1.0, 2.0))
+    )
+
+    assert fit.figure_of_merit == pytest.approx(-2849711.5317237, 1.0e-4)
+
+
 def test__galaxy_model_image_dict(masked_imaging_7x7):
 
     # Normal Light Profiles Only

--- a/test_autolens/interferometer/test_simulator.py
+++ b/test_autolens/interferometer/test_simulator.py
@@ -105,8 +105,6 @@ class TestSimulatorInterferometer:
             image=tracer.image_2d_from(grid=grid)
         )
 
-        assert dataset.data == pytest.approx(
-            interferometer_via_image.data, 1.0e-4
-        )
+        assert dataset.data == pytest.approx(interferometer_via_image.data, 1.0e-4)
         assert (dataset.uv_wavelengths == interferometer_via_image.uv_wavelengths).all()
         assert (interferometer_via_image.noise_map == dataset.noise_map).all()

--- a/test_autolens/interferometer/test_simulator.py
+++ b/test_autolens/interferometer/test_simulator.py
@@ -30,7 +30,7 @@ class TestSimulatorInterferometer:
             image=tracer.image_2d_from(grid=grid)
         )
 
-        assert (dataset.data == interferometer_via_image.visibilities).all()
+        assert (dataset.data == interferometer_via_image.data).all()
         assert (dataset.uv_wavelengths == interferometer_via_image.uv_wavelengths).all()
         assert (dataset.noise_map == interferometer_via_image.noise_map).all()
 
@@ -61,7 +61,7 @@ class TestSimulatorInterferometer:
             image=tracer.image_2d_from(grid=grid)
         )
 
-        assert (dataset.data == interferometer_via_image.visibilities).all()
+        assert (dataset.data == interferometer_via_image.data).all()
         assert (interferometer_via_image.uv_wavelengths == dataset.uv_wavelengths).all()
         assert (dataset.noise_map == interferometer_via_image.noise_map).all()
 
@@ -106,7 +106,7 @@ class TestSimulatorInterferometer:
         )
 
         assert dataset.data == pytest.approx(
-            interferometer_via_image.visibilities, 1.0e-4
+            interferometer_via_image.data, 1.0e-4
         )
         assert (dataset.uv_wavelengths == interferometer_via_image.uv_wavelengths).all()
         assert (interferometer_via_image.noise_map == dataset.noise_map).all()


### PR DESCRIPTION
Extends the `DatasetModel` object added in https://github.com/Jammy2211/PyAutoArray/pull/101 to include a `grid_offset` parameter.

This parameter accounts for (y,x) offsets between two datasets. It is subtracted from one dataset so as to shift the grids associated with it, which are used to perform calculations which fit the dataset, to align with another dataset.

The `DatasetModel` can be passed into a `FitImaging` or `FitInterferometer` object with a `grid_offset` and the shift will be applied before computing the model-image and log likelihood.

In the projects **PyAutoGalaxy** and **PyAutoLens** the `grid_offset` (y,x) values can be treated free parameters fitted for as part of a model-fit. 

This means offsets between datasets (e.g. due to pointing errors) can be properly accounted for and marginalized over.

The following example scripts show examples of this for **PyAutoGalaxy** and **PyAutoLens**:

https://github.com/Jammy2211/autogalaxy_workspace/blob/main/scripts/multi/modeling/features/dataset_offsets.py
https://github.com/Jammy2211/autolens_workspace/blob/main/scripts/multi/modeling/features/dataset_offsets.py