### PR TITLE
Feature/over sample non uniform

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -5,6 +5,7 @@ from autoarray.dataset.imaging.dataset import Imaging
 from autoarray.dataset.interferometer.dataset import (
     Interferometer,
 )
+from autoarray.dataset.over_sampling import OverSamplingDataset
 from autoarray.dataset.dataset_model import DatasetModel
 from autoarray.mask.mask_1d import Mask1D
 from autoarray.mask.mask_2d import Mask2D

--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -6,6 +6,7 @@ from autoarray.dataset.interferometer.dataset import (
     Interferometer,
 )
 from autoarray.dataset.over_sampling import OverSamplingDataset
+from autoarray.dataset.grids import GridsInterface
 from autoarray.dataset.dataset_model import DatasetModel
 from autoarray.mask.mask_1d import Mask1D
 from autoarray.mask.mask_2d import Mask2D

--- a/autolens/analysis/preloads.py
+++ b/autolens/analysis/preloads.py
@@ -159,11 +159,11 @@ class Preloads(ag.Preloads):
         self.traced_grids_of_planes_for_inversion = None
 
         traced_grids_of_planes_0 = fit_0.tracer.traced_grid_2d_list_from(
-            grid=fit_0.grid_pixelization
+            grid=fit_0.grids.pixelization
         )
 
         traced_grids_of_planes_1 = fit_1.tracer.traced_grid_2d_list_from(
-            grid=fit_1.grid_pixelization
+            grid=fit_1.grids.pixelization
         )
 
         if traced_grids_of_planes_0[-1] is not None:

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -85,6 +85,20 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         self.preloads = preloads
 
     @property
+    def grid(self) -> aa.type.Grid2DLike:
+        grid = self.dataset.grid.subtracted_from(offset=self.dataset_model.grid_offset)
+
+        if self.dataset.over_sampling.non_uniform is None:
+            return grid
+
+        return aa.Grid2D(
+            values=grid,
+            mask=self.dataset.mask,
+            over_sampling=self.dataset.over_sampling.non_uniform,
+            over_sampling_non_uniform=self.dataset.over_sampling.non_uniform
+        )
+
+    @property
     def blurred_image(self) -> aa.Array2D:
         """
         Returns the image of all light profiles in the fit's tracer convolved with the imaging dataset's PSF.

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -98,6 +98,29 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
     #         over_sampling_non_uniform=self.dataset.over_sampling.non_uniform
     #     )
 
+    @cached_property
+    def grids(self) -> aa.GridsInterface:
+
+        grids = super().grids
+
+        if grids.non_uniform is None:
+            return grids
+
+        uniform = aa.Grid2D(
+            values=grids.non_uniform,
+            mask=self.dataset.mask,
+            over_sampling=self.dataset.over_sampling.non_uniform,
+            over_sampling_non_uniform=self.dataset.over_sampling.non_uniform
+        )
+
+        return aa.GridsInterface(
+            uniform=uniform,
+            non_uniform=grids.non_uniform,
+            pixelization=grids.pixelization,
+            blurring=grids.blurring,
+            border_relocator=grids.border_relocator
+        )
+
     @property
     def blurred_image(self) -> aa.Array2D:
         """

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -84,19 +84,19 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
 
         self.preloads = preloads
 
-    @property
-    def grid(self) -> aa.type.Grid2DLike:
-        grid = self.dataset.grid.subtracted_from(offset=self.dataset_model.grid_offset)
-
-        if self.dataset.over_sampling.non_uniform is None:
-            return grid
-
-        return aa.Grid2D(
-            values=grid,
-            mask=self.dataset.mask,
-            over_sampling=self.dataset.over_sampling.non_uniform,
-            over_sampling_non_uniform=self.dataset.over_sampling.non_uniform
-        )
+    # @property
+    # def grid(self) -> aa.type.Grid2DLike:
+    #     grid = self.dataset.grid.subtracted_from(offset=self.dataset_model.grid_offset)
+    #
+    #     if self.dataset.over_sampling.non_uniform is None:
+    #         return grid
+    #
+    #     return aa.Grid2D(
+    #         values=grid,
+    #         mask=self.dataset.mask,
+    #         over_sampling=self.dataset.over_sampling.non_uniform,
+    #         over_sampling_non_uniform=self.dataset.over_sampling.non_uniform
+    #     )
 
     @property
     def blurred_image(self) -> aa.Array2D:
@@ -110,9 +110,9 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         if self.preloads.blurred_image is None:
 
             return self.tracer.blurred_image_2d_from(
-                grid=self.grid,
+                grid=self.grids.uniform,
                 convolver=self.dataset.convolver,
-                blurring_grid=self.blurring_grid,
+                blurring_grid=self.grids.blurring,
             )
 
         return self.preloads.blurred_image
@@ -131,14 +131,10 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         dataset = aa.DatasetInterface(
             data=self.profile_subtracted_image,
             noise_map=self.noise_map,
+            grids=self.grids,
             convolver=self.dataset.convolver,
             w_tilde=self.w_tilde,
-            grid=self.grid,
-            grid_pixelization=self.grid_pixelization,
-            blurring_grid=self.blurring_grid,
-            border_relocator=self.dataset.border_relocator,
         )
-
 
         return TracerToInversion(
             dataset=dataset,
@@ -196,9 +192,9 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         """
 
         galaxy_blurred_image_2d_dict = self.tracer.galaxy_blurred_image_2d_dict_from(
-            grid=self.grid,
+            grid=self.grids.uniform,
             convolver=self.dataset.convolver,
-            blurring_grid=self.blurring_grid,
+            blurring_grid=self.grids.blurring,
         )
 
         galaxy_linear_obj_image_dict = self.galaxy_linear_obj_data_dict_from(
@@ -267,7 +263,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
 
         model_images_of_planes_list = [
             aa.Array2D(
-            values=np.zeros(self.grid.shape_slim), mask=self.dataset.mask
+            values=np.zeros(self.grids.uniform.shape_slim), mask=self.dataset.mask
             )
             for i in range(self.tracer.total_planes)
         ]
@@ -323,7 +319,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             exc.raise_linear_light_profile_in_unmasked()
 
         return self.tracer.unmasked_blurred_image_2d_from(
-            grid=self.grid, psf=self.dataset.psf
+            grid=self.grids.uniform, psf=self.dataset.psf
         )
 
     @property
@@ -339,7 +335,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             exc.raise_linear_light_profile_in_unmasked()
 
         return self.tracer.unmasked_blurred_image_2d_list_from(
-            grid=self.grid, psf=self.dataset.psf
+            grid=self.grids.uniform, psf=self.dataset.psf
         )
 
     @property

--- a/autolens/imaging/model/visualizer.py
+++ b/autolens/imaging/model/visualizer.py
@@ -115,7 +115,7 @@ class VisualizerImaging(af.Visualizer):
             tracer=tracer, grid=grid, during_analysis=during_analysis
         )
         plotter_interface.galaxies(
-            galaxies=tracer.galaxies, grid=fit.grid, during_analysis=during_analysis
+            galaxies=tracer.galaxies, grid=fit.grids.uniform, during_analysis=during_analysis
         )
         if fit.inversion is not None:
             if fit.inversion.has(cls=ag.AbstractMapper):

--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -99,7 +99,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         transform to the sum of light profile images.
         """
         return self.tracer.visibilities_from(
-            grid=self.grid, transformer=self.dataset.transformer
+            grid=self.grids.uniform, transformer=self.dataset.transformer
         )
 
     @property
@@ -115,11 +115,9 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         dataset = aa.DatasetInterface(
             data=self.profile_subtracted_visibilities,
             noise_map=self.noise_map,
+            grids=self.grids,
             transformer=self.dataset.transformer,
             w_tilde=self.w_tilde,
-            grid=self.grid,
-            grid_pixelization=self.grid_pixelization,
-            border_relocator=self.dataset.border_relocator,
         )
 
         return TracerToInversion(
@@ -173,7 +171,9 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         For modeling, this dictionary is used to set up the `adapt_images` that adapt certain pixelizations to the
         data being fitted.
         """
-        galaxy_model_image_dict = self.tracer.galaxy_image_2d_dict_from(grid=self.grid)
+        galaxy_model_image_dict = self.tracer.galaxy_image_2d_dict_from(
+            grid=self.grids.uniform
+        )
 
         galaxy_linear_obj_image_dict = self.galaxy_linear_obj_data_dict_from(
             use_image=True
@@ -194,7 +194,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
           are solved for first via the inversion.
         """
         galaxy_model_visibilities_dict = self.tracer.galaxy_visibilities_dict_from(
-            grid=self.grid, transformer=self.dataset.transformer
+            grid=self.grids.uniform, transformer=self.dataset.transformer
         )
 
         galaxy_linear_obj_visibilities_dict = self.galaxy_linear_obj_data_dict_from(

--- a/autolens/interferometer/model/visualizer.py
+++ b/autolens/interferometer/model/visualizer.py
@@ -105,10 +105,12 @@ class VisualizerInterferometer(af.Visualizer):
         tracer = fit.tracer_linear_light_profiles_to_light_profiles
 
         plotter_interface.tracer(
-            tracer=tracer, grid=fit.grid, during_analysis=during_analysis
+            tracer=tracer, grid=fit.grids.uniform, during_analysis=during_analysis
         )
         plotter_interface.galaxies(
-            galaxies=tracer.galaxies, grid=fit.grid, during_analysis=during_analysis
+            galaxies=tracer.galaxies,
+            grid=fit.grids.uniform,
+            during_analysis=during_analysis,
         )
         if fit.inversion is not None:
             try:

--- a/autolens/interferometer/plot/fit_interferometer_plotters.py
+++ b/autolens/interferometer/plot/fit_interferometer_plotters.py
@@ -120,7 +120,7 @@ class FitInterferometerPlotter(Plotter):
         """
         return TracerPlotter(
             tracer=self.tracer,
-            grid=self.fit.grid,
+            grid=self.fit.grids.uniform,
             mat_plot_2d=self.mat_plot_2d,
             visuals_2d=self.visuals_2d,
             include_2d=self.include_2d,

--- a/autolens/plot/get_visuals/two_d.py
+++ b/autolens/plot/get_visuals/two_d.py
@@ -172,7 +172,7 @@ class GetVisuals2D(gv2d.GetVisuals2D):
         visuals_2d_via_mask = self.via_mask_from(mask=fit.mask)
 
         visuals_2d_via_tracer = self.via_tracer_from(
-            tracer=fit.tracer, grid=fit.grid, plane_index=0
+            tracer=fit.tracer, grid=fit.grids.uniform, plane_index=0
         )
 
         return visuals_2d_via_mask + visuals_2d_via_tracer

--- a/autolens/quantity/fit_quantity.py
+++ b/autolens/quantity/fit_quantity.py
@@ -1,4 +1,3 @@
-import autoarray as aa
 import autogalaxy as ag
 
 from autogalaxy.quantity.dataset_quantity import DatasetQuantity

--- a/autolens/quantity/model/result.py
+++ b/autolens/quantity/model/result.py
@@ -43,7 +43,7 @@ class ResultQuantity(Result):
         """
         The masked 2D grid used by the dataset in the model-fit.
         """
-        return self.analysis.dataset.grid
+        return self.analysis.dataset.grids.uniform
 
     @property
     def max_log_likelihood_tracer(self) -> Tracer:

--- a/autolens/quantity/model/visualizer.py
+++ b/autolens/quantity/model/visualizer.py
@@ -56,6 +56,6 @@ class VisualizerQuantity(af.Visualizer):
         plotter_interface = PlotterInterface(image_path=paths.image_path)
         plotter_interface.tracer(
             tracer=fit.tracer,
-            grid=analysis.dataset.grid,
+            grid=analysis.dataset.grids.uniform,
             during_analysis=during_analysis,
         )

--- a/docs/overview/overview_2_fit.rst
+++ b/docs/overview/overview_2_fit.rst
@@ -104,7 +104,7 @@ data below.
 
 .. code-block:: python
 
-    grid_plotter = aplt.Grid2DPlotter(grid=dataset.grid)
+    grid_plotter = aplt.Grid2DPlotter(grid=dataset.grids.uniform)
     grid_plotter.set_title("Grid2D of Masked Dataset")
     grid_plotter.figure_2d()
 
@@ -161,7 +161,7 @@ the telescope optics when it is observed. It mimics this blurring effect via a 2
 
 .. code-block:: python
 
-    tracer_plotter = aplt.TracerPlotter(tracer=tracer, grid=dataset.grid)
+    tracer_plotter = aplt.TracerPlotter(tracer=tracer, grid=dataset.grids.uniform)
     tracer_plotter.set_title("Tracer`s Image")
     tracer_plotter.figures_2d(image=True)
 

--- a/docs/overview/overview_3_modeling.rst
+++ b/docs/overview/overview_3_modeling.rst
@@ -537,7 +537,7 @@ The result also contains the maximum log likelihood `Tracer` and `FitImaging` ob
 .. code-block:: python
 
     tracer_plotter = aplt.TracerPlotter(
-        tracer=result.max_log_likelihood_tracer, grid=dataset.grid
+        tracer=result.max_log_likelihood_tracer, grid=dataset.grids.uniform
     )
     tracer_plotter.subplot_tracer()
 

--- a/test_autolens/analysis/test_analysis.py
+++ b/test_autolens/analysis/test_analysis.py
@@ -95,7 +95,7 @@ def test__use_border_relocator__determines_if_border_pixel_relocation_is_used(
         )
     )
 
-    masked_imaging_7x7.grid[4] = np.array([300.0, 0.0])
+    masked_imaging_7x7.grids.uniform[4] = np.array([300.0, 0.0])
 
     analysis = al.AnalysisImaging(
         dataset=masked_imaging_7x7,

--- a/test_autolens/analysis/test_plotter_interface.py
+++ b/test_autolens/analysis/test_plotter_interface.py
@@ -23,7 +23,9 @@ def test__tracer(
     plotter_interface = vis.PlotterInterface(image_path=plot_path)
 
     plotter_interface.tracer(
-        tracer=tracer_x2_plane_7x7, grid=masked_imaging_7x7.grid, during_analysis=False
+        tracer=tracer_x2_plane_7x7,
+        grid=masked_imaging_7x7.grids.uniform,
+        during_analysis=False,
     )
 
     plot_path = path.join(plot_path, "tracer")

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -531,9 +531,9 @@ def test__galaxy_model_image_dict(masked_imaging_7x7):
     fit = al.FitImaging(dataset=masked_imaging_7x7, tracer=tracer)
 
     blurred_image_2d_list = tracer.blurred_image_2d_list_from(
-        grid=masked_imaging_7x7.grid,
+        grid=masked_imaging_7x7.grids.uniform,
         convolver=masked_imaging_7x7.convolver,
-        blurring_grid=masked_imaging_7x7.blurring_grid,
+        blurring_grid=masked_imaging_7x7.grids.blurring,
     )
 
     assert fit.galaxy_model_image_dict[g0] == pytest.approx(
@@ -646,20 +646,20 @@ def test__subtracted_image_of_galaxies_dict(masked_imaging_7x7):
     fit = al.FitImaging(dataset=masked_imaging_7x7, tracer=tracer)
 
     g0_image = g0.blurred_image_2d_from(
-        grid=masked_imaging_7x7.grid,
-        blurring_grid=masked_imaging_7x7.blurring_grid,
+        grid=masked_imaging_7x7.grids.uniform,
+        blurring_grid=masked_imaging_7x7.grids.blurring,
         convolver=masked_imaging_7x7.convolver
     )
 
     g1_image = g1.blurred_image_2d_from(
-        grid=masked_imaging_7x7.grid,
-        blurring_grid=masked_imaging_7x7.blurring_grid,
+        grid=masked_imaging_7x7.grids.uniform,
+        blurring_grid=masked_imaging_7x7.grids.blurring,
         convolver=masked_imaging_7x7.convolver
     )
 
     g2_image = g2.blurred_image_2d_from(
-        grid=masked_imaging_7x7.grid,
-        blurring_grid=masked_imaging_7x7.blurring_grid,
+        grid=masked_imaging_7x7.grids.uniform,
+        blurring_grid=masked_imaging_7x7.grids.blurring,
         convolver=masked_imaging_7x7.convolver
     )
 
@@ -688,9 +688,9 @@ def test__subtracted_image_of_galaxies_dict(masked_imaging_7x7):
     fit = al.FitImaging(dataset=masked_imaging_7x7, tracer=tracer)
 
     blurred_image_2d_list = tracer.blurred_image_2d_list_from(
-        grid=masked_imaging_7x7.grid,
+        grid=masked_imaging_7x7.grids.uniform,
         convolver=masked_imaging_7x7.convolver,
-        blurring_grid=masked_imaging_7x7.blurring_grid,
+        blurring_grid=masked_imaging_7x7.grids.blurring,
     )
 
     assert fit.subtracted_images_of_galaxies_dict[g0] == pytest.approx(
@@ -792,19 +792,19 @@ def test___unmasked_blurred_images(masked_imaging_7x7):
     fit = al.FitImaging(dataset=masked_imaging_7x7, tracer=tracer)
 
     blurred_images_of_planes = tracer.blurred_image_2d_list_from(
-        grid=masked_imaging_7x7.grid,
+        grid=masked_imaging_7x7.grids.uniform,
         convolver=masked_imaging_7x7.convolver,
-        blurring_grid=masked_imaging_7x7.blurring_grid,
+        blurring_grid=masked_imaging_7x7.grids.blurring,
     )
 
     unmasked_blurred_image = tracer.unmasked_blurred_image_2d_from(
-        grid=masked_imaging_7x7.grid, psf=masked_imaging_7x7.psf
+        grid=masked_imaging_7x7.grids.uniform, psf=masked_imaging_7x7.psf
     )
 
     assert (fit.unmasked_blurred_image == unmasked_blurred_image).all()
 
     unmasked_blurred_image_of_planes_list = tracer.unmasked_blurred_image_2d_list_from(
-        grid=masked_imaging_7x7.grid, psf=masked_imaging_7x7.psf
+        grid=masked_imaging_7x7.grids.uniform, psf=masked_imaging_7x7.psf
     )
 
     assert (

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -238,7 +238,7 @@ def test__fit_figure_of_merit__sub_2(image_7x7, psf_3x3, noise_map_7x7, mask_2d_
         data=image_7x7,
         psf=psf_3x3,
         noise_map=noise_map_7x7,
-        over_sampling=al.OverSamplingUniform(sub_size=2),
+        over_sampling=al.OverSamplingDataset(uniform=al.OverSamplingUniform(sub_size=2)),
     )
 
     masked_imaging_7x7 = dataset.apply_mask(

--- a/test_autolens/imaging/test_simulate_and_fit_imaging.py
+++ b/test_autolens/imaging/test_simulate_and_fit_imaging.py
@@ -735,6 +735,91 @@ def test__simulate_imaging_data_and_fit__complex_fit_compare_mapping_matrix_w_ti
     )
 
 
+def test__perfect_fit__chi_squared_0__non_uniform_over_sampling():
+
+    over_sampling = al.OverSamplingUniform(sub_size=8)
+
+    grid = al.Grid2D.uniform(
+        shape_native=(31, 31),
+        pixel_scales=0.2,
+        over_sampling=over_sampling
+    )
+
+    psf = al.Kernel2D.from_gaussian(
+        shape_native=(3, 3), pixel_scales=0.2, sigma=0.75, normalize=True
+    )
+
+    lens_galaxy = al.Galaxy(
+        redshift=0.5,
+        mass=al.mp.Isothermal(centre=(0.1, 0.1), einstein_radius=0.3),
+    )
+    source_galaxy = al.Galaxy(
+        redshift=1.0, light=al.lp.Sersic(centre=(0.1, 0.1), intensity=0.5, sersic_index=1.0)
+    )
+    tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
+
+    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise=False)
+
+    dataset = dataset.via_tracer_from(tracer=tracer, grid=grid)
+    dataset.noise_map = al.Array2D.ones(
+        shape_native=dataset.data.shape_native, pixel_scales=0.2
+    )
+
+    file_path = path.join(
+        "{}".format(path.dirname(path.realpath(__file__))),
+        "data_temp",
+        "simulate_and_fit",
+    )
+
+    try:
+        shutil.rmtree(file_path)
+    except FileNotFoundError:
+        pass
+
+    if path.exists(file_path) is False:
+        os.makedirs(file_path)
+
+    dataset.output_to_fits(
+        data_path=path.join(file_path, "data.fits"),
+        noise_map_path=path.join(file_path, "noise_map.fits"),
+        psf_path=path.join(file_path, "psf.fits"),
+    )
+
+    dataset = al.Imaging.from_fits(
+        data_path=path.join(file_path, "data.fits"),
+        noise_map_path=path.join(file_path, "noise_map.fits"),
+        psf_path=path.join(file_path, "psf.fits"),
+        pixel_scales=0.2,
+    )
+
+    mask = al.Mask2D.circular(
+        shape_native=dataset.data.shape_native, pixel_scales=0.2, radius=1.5
+    )
+
+    masked_dataset = dataset.apply_mask(mask=mask)
+
+    traced_grid = tracer.traced_grid_2d_list_from(
+        grid=masked_dataset.grid,
+    )[-1]
+
+    masked_dataset = masked_dataset.apply_over_sampling(
+        over_sampling_non_uniform=al.OverSamplingUniform.from_radial_bins(
+            grid=traced_grid, sub_size_list=[8, 2], radial_list=[0.3], centre_list=[source_galaxy.light.centre]
+        )
+    )
+
+    tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
+
+    fit = al.FitImaging(dataset=masked_dataset, tracer=tracer)
+
+    assert fit.chi_squared < 0.1
+
+    file_path = path.join(
+        "{}".format(path.dirname(path.realpath(__file__))), "data_temp"
+    )
+
+    if path.exists(file_path) is True:
+        shutil.rmtree(file_path)
 
 
 def test__fit_figure_of_merit__mge_mass_model(masked_imaging_7x7, masked_imaging_covariance_7x7):

--- a/test_autolens/imaging/test_simulate_and_fit_imaging.py
+++ b/test_autolens/imaging/test_simulate_and_fit_imaging.py
@@ -755,7 +755,7 @@ def test__perfect_fit__chi_squared_0__non_uniform_over_sampling():
         mass=al.mp.Isothermal(centre=(0.1, 0.1), einstein_radius=0.3),
     )
     source_galaxy = al.Galaxy(
-        redshift=1.0, light=al.lp.Sersic(centre=(0.1, 0.1), intensity=0.5, sersic_index=1.0)
+        redshift=1.0, light=al.lp.Sersic(centre=(0.1, 0.1), intensity=0.5, sersic_index=1.2)
     )
     tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
 
@@ -804,7 +804,9 @@ def test__perfect_fit__chi_squared_0__non_uniform_over_sampling():
     )[-1]
 
     masked_dataset = masked_dataset.apply_over_sampling(
-        over_sampling=al.OverSamplingDataset(non_uniform=al.OverSamplingUniform.from_radial_bins(
+        over_sampling=al.OverSamplingDataset(
+            uniform=al.OverSamplingUniform(sub_size=1),
+            non_uniform=al.OverSamplingUniform.from_radial_bins(
             grid=traced_grid, sub_size_list=[8, 2], radial_list=[0.3], centre_list=[source_galaxy.light.centre]
         ))
     )

--- a/test_autolens/imaging/test_simulate_and_fit_imaging.py
+++ b/test_autolens/imaging/test_simulate_and_fit_imaging.py
@@ -272,9 +272,9 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_agree_with_standa
     assert fit_linear.figure_of_merit == pytest.approx(-45.02798, 1.0e-4)
 
     lens_galaxy_image = lens_galaxy.blurred_image_2d_from(
-        grid=masked_dataset.grid,
+        grid=masked_dataset.grids.uniform,
         convolver=masked_dataset.convolver,
-        blurring_grid=masked_dataset.blurring_grid,
+        blurring_grid=masked_dataset.grids.blurring,
     )
 
     assert fit_linear.galaxy_model_image_dict[lens_galaxy_linear] == pytest.approx(
@@ -284,9 +284,9 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_agree_with_standa
         lens_galaxy_image, 1.0e-4
     )
 
-    traced_grid_2d_list = tracer.traced_grid_2d_list_from(grid=masked_dataset.grid)
+    traced_grid_2d_list = tracer.traced_grid_2d_list_from(grid=masked_dataset.grids.uniform)
     traced_blurring_grid_2d_list = tracer.traced_grid_2d_list_from(
-        grid=masked_dataset.blurring_grid
+        grid=masked_dataset.grids.blurring
     )
 
     source_galaxy_image = source_galaxy.blurred_image_2d_from(
@@ -387,9 +387,9 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_and_pixelization(
     assert fit_linear.figure_of_merit == pytest.approx(-84.04875317, 1.0e-4)
 
     lens_galaxy_image = lens_galaxy.blurred_image_2d_from(
-        grid=masked_dataset.grid,
+        grid=masked_dataset.grids.uniform,
         convolver=masked_dataset.convolver,
-        blurring_grid=masked_dataset.blurring_grid,
+        blurring_grid=masked_dataset.grids.blurring,
     )
 
     assert fit_linear.galaxy_model_image_dict[lens_galaxy_linear] == pytest.approx(
@@ -523,7 +523,6 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_and_pixelization_
         settings_inversion=al.SettingsInversion(use_w_tilde=False),
     )
 
-    print(fit_linear.inversion.reconstruction)
 
     assert fit_linear.inversion.reconstruction == pytest.approx(
         np.array(
@@ -534,13 +533,13 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_and_pixelization_
         ),
         1.0e-4,
     )
-    print(fit_linear.figure_of_merit)
+
     assert fit_linear.figure_of_merit == pytest.approx(-84.36224277776512, 1.0e-4)
 
     lens_galaxy_image = lens_galaxy.blurred_image_2d_from(
-        grid=masked_dataset.grid,
+        grid=masked_dataset.grids.uniform,
         convolver=masked_dataset.convolver,
-        blurring_grid=masked_dataset.blurring_grid,
+        blurring_grid=masked_dataset.grids.blurring,
     )
 
     assert fit_linear.galaxy_model_image_dict[lens_galaxy_linear] == pytest.approx(
@@ -801,7 +800,7 @@ def test__perfect_fit__chi_squared_0__non_uniform_over_sampling():
     masked_dataset = dataset.apply_mask(mask=mask)
 
     traced_grid = tracer.traced_grid_2d_list_from(
-        grid=masked_dataset.grid,
+        grid=masked_dataset.grids.uniform,
     )[-1]
 
     masked_dataset = masked_dataset.apply_over_sampling(

--- a/test_autolens/imaging/test_simulate_and_fit_imaging.py
+++ b/test_autolens/imaging/test_simulate_and_fit_imaging.py
@@ -131,7 +131,7 @@ def test__perfect_fit__chi_squared_0__use_grid_iterate_to_simulate_and_fit():
         noise_map_path=path.join(file_path, "noise_map.fits"),
         psf_path=path.join(file_path, "psf.fits"),
         pixel_scales=0.2,
-        over_sampling=over_sampling
+        over_sampling=al.OverSamplingDataset(uniform=over_sampling)
     )
 
     mask = al.Mask2D.circular(
@@ -492,8 +492,10 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_and_pixelization_
         data=dataset.data,
         psf=dataset.psf,
         noise_map=dataset.noise_map,
-        over_sampling=al.OverSamplingUniform(sub_size=2),
-        over_sampling_pixelization=al.OverSamplingUniform(sub_size=2),
+        over_sampling=al.OverSamplingDataset(
+            uniform=al.OverSamplingUniform(sub_size=2),
+            pixelization=al.OverSamplingUniform(sub_size=2)
+        )
     )
 
     masked_dataset = dataset.apply_mask(mask=mask)
@@ -803,9 +805,9 @@ def test__perfect_fit__chi_squared_0__non_uniform_over_sampling():
     )[-1]
 
     masked_dataset = masked_dataset.apply_over_sampling(
-        over_sampling_non_uniform=al.OverSamplingUniform.from_radial_bins(
+        over_sampling=al.OverSamplingDataset(non_uniform=al.OverSamplingUniform.from_radial_bins(
             grid=traced_grid, sub_size_list=[8, 2], radial_list=[0.3], centre_list=[source_galaxy.light.centre]
-        )
+        ))
     )
 
     tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
@@ -876,7 +878,7 @@ def test__fit_figure_of_merit__mge_mass_model(masked_imaging_7x7, masked_imaging
         noise_map_path=path.join(file_path, "noise_map.fits"),
         psf_path=path.join(file_path, "psf.fits"),
         pixel_scales=0.2,
-        over_sampling=over_sampling
+        over_sampling=al.OverSamplingDataset(uniform=over_sampling)
     )
 
     mask = al.Mask2D.circular(
@@ -908,7 +910,7 @@ def test__fit_figure_of_merit__mge_mass_model(masked_imaging_7x7, masked_imaging
     over_sampling = al.OverSamplingUniform(sub_size=8)
 
     masked_dataset = masked_dataset.apply_over_sampling(
-        over_sampling=over_sampling
+        al.OverSamplingDataset(uniform=over_sampling)
     )
 
     basis = al.lp_basis.Basis(

--- a/test_autolens/interferometer/test_fit_interferometer.py
+++ b/test_autolens/interferometer/test_fit_interferometer.py
@@ -176,7 +176,7 @@ def test___galaxy_model_image_dict(interferometer_7, interferometer_7_grid):
     )
 
     traced_grid_2d_list_from = tracer.traced_grid_2d_list_from(
-        grid=interferometer_7_grid.grid
+        grid=interferometer_7.grids.uniform
     )
 
     g0_image = g0.image_2d_from(grid=traced_grid_2d_list_from[0])
@@ -275,7 +275,7 @@ def test__galaxy_model_visibilities_dict(interferometer_7, interferometer_7_grid
     fit = al.FitInterferometer(dataset=interferometer_7, tracer=tracer)
 
     traced_grid_2d_list_from = tracer.traced_grid_2d_list_from(
-        grid=interferometer_7_grid.grid
+        grid=interferometer_7.grids.uniform
     )
 
     g0_profile_visibilities = g0.visibilities_from(

--- a/test_autolens/interferometer/test_simulate_and_fit_interferometer.py
+++ b/test_autolens/interferometer/test_simulate_and_fit_interferometer.py
@@ -214,13 +214,13 @@ def test__simulate_interferometer_data_and_fit__linear_light_profiles_agree_with
     ] == pytest.approx(0.2, 1.0e-2)
     assert fit.log_likelihood == pytest.approx(fit_linear.log_likelihood)
 
-    lens_galaxy_image = lens_galaxy.image_2d_from(grid=dataset.grid)
+    lens_galaxy_image = lens_galaxy.image_2d_from(grid=dataset.grids.uniform)
 
     assert fit_linear.galaxy_model_image_dict[lens_galaxy_linear] == pytest.approx(
         lens_galaxy_image, 1.0e-4
     )
 
-    traced_grid_2d_list = tracer.traced_grid_2d_list_from(grid=dataset.grid)
+    traced_grid_2d_list = tracer.traced_grid_2d_list_from(grid=dataset.grids.uniform)
 
     source_galaxy_image = source_galaxy.image_2d_from(grid=traced_grid_2d_list[1])
 
@@ -229,7 +229,7 @@ def test__simulate_interferometer_data_and_fit__linear_light_profiles_agree_with
     )
 
     lens_galaxy_visibilities = lens_galaxy.visibilities_from(
-        grid=dataset.grid, transformer=dataset.transformer
+        grid=dataset.grids.uniform, transformer=dataset.transformer
     )
 
     assert fit_linear.galaxy_model_visibilities_dict[
@@ -317,13 +317,13 @@ def test__simulate_interferometer_data_and_fit__linear_light_profiles_and_pixeli
     )
     assert fit_linear.figure_of_merit == pytest.approx(-29.20551989, 1.0e-4)
 
-    lens_galaxy_image = lens_galaxy.image_2d_from(grid=dataset.grid)
+    lens_galaxy_image = lens_galaxy.image_2d_from(grid=dataset.grids.uniform)
 
     assert fit_linear.galaxy_model_image_dict[lens_galaxy_linear] == pytest.approx(
         lens_galaxy_image, 1.0e-2
     )
 
-    traced_grid_2d_list = tracer.traced_grid_2d_list_from(grid=dataset.grid)
+    traced_grid_2d_list = tracer.traced_grid_2d_list_from(grid=dataset.grids.uniform)
 
     source_galaxy_image = source_galaxy.image_2d_from(grid=traced_grid_2d_list[1])
 

--- a/test_autolens/lens/test_to_inversion.py
+++ b/test_autolens/lens/test_to_inversion.py
@@ -57,9 +57,13 @@ def test__lp_linear_func_galaxy_dict_from(masked_imaging_7x7):
     assert lp_linear_func_list[1].light_profile_list[0] == lp_linear_1
     assert lp_linear_func_list[2].light_profile_list[0] == lp_linear_2
 
-    traced_grid_list = tracer.traced_grid_2d_list_from(grid=masked_imaging_7x7.grid)
+    traced_grid_list = tracer.traced_grid_2d_list_from(
+        grid=masked_imaging_7x7.grids.uniform
+    )
 
-    assert lp_linear_func_list[0].grid == pytest.approx(masked_imaging_7x7.grid, 1.0e-4)
+    assert lp_linear_func_list[0].grid == pytest.approx(
+        masked_imaging_7x7.grids.uniform, 1.0e-4
+    )
     assert lp_linear_func_list[1].grid == pytest.approx(traced_grid_list[1], 1.0e-4)
     assert lp_linear_func_list[2].grid == pytest.approx(traced_grid_list[2], 1.0e-4)
 
@@ -456,14 +460,18 @@ def test__mapper_galaxy_dict(masked_imaging_7x7):
 
 
 def test__inversion_imaging_from(grid_2d_7x7, masked_imaging_7x7):
+    grids = al.GridsInterface(
+        uniform=masked_imaging_7x7.grids.uniform,
+        pixelization=masked_imaging_7x7.grids.pixelization,
+        blurring=masked_imaging_7x7.grids.blurring,
+        border_relocator=masked_imaging_7x7.grids.border_relocator,
+    )
+
     dataset = al.DatasetInterface(
         data=masked_imaging_7x7.data,
         noise_map=masked_imaging_7x7.noise_map,
+        grids=grids,
         convolver=masked_imaging_7x7.convolver,
-        grid=masked_imaging_7x7.grid,
-        grid_pixelization=masked_imaging_7x7.grid_pixelization,
-        blurring_grid=masked_imaging_7x7.blurring_grid,
-        border_relocator=masked_imaging_7x7.border_relocator,
     )
 
     g_linear = al.Galaxy(redshift=0.5, light_linear=al.lp_linear.Sersic())
@@ -505,14 +513,18 @@ def test__inversion_imaging_from(grid_2d_7x7, masked_imaging_7x7):
 def test__inversion_interferometer_from(grid_2d_7x7, interferometer_7):
     interferometer_7.data = al.Visibilities.ones(shape_slim=(7,))
 
+    grids = al.GridsInterface(
+        uniform=interferometer_7.grids.uniform,
+        pixelization=interferometer_7.grids.pixelization,
+        blurring=interferometer_7.grids.blurring,
+        border_relocator=interferometer_7.grids.border_relocator,
+    )
+
     dataset = al.DatasetInterface(
         data=interferometer_7.data,
         noise_map=interferometer_7.noise_map,
+        grids=grids,
         transformer=interferometer_7.transformer,
-        grid=interferometer_7.grid,
-        grid_pixelization=interferometer_7.grid_pixelization,
-        blurring_grid=interferometer_7.blurring_grid,
-        border_relocator=interferometer_7.border_relocator,
     )
 
     g_linear = al.Galaxy(redshift=0.5, light_linear=al.lp_linear.Sersic())


### PR DESCRIPTION
Refactors over sampling and implements an additional form which computes lensed source emission on a non-uniform over sampled grid input by a user, as described in the following example:

https://github.com/Jammy2211/autolens_workspace/blob/main/scripts/imaging/advanced/chaining/examples/over_sample.py