### PR TITLE
Feature/visualization title

### DIFF
--- a/autolens/analysis/analysis.py
+++ b/autolens/analysis/analysis.py
@@ -145,6 +145,7 @@ class AnalysisDataset(AgAnalysisDataset, AnalysisLens):
         cosmology: ag.cosmo.LensingCosmology = ag.cosmo.Planck15(),
         settings_inversion: aa.SettingsInversion = None,
         raise_inversion_positions_likelihood_exception: bool = True,
+        title_prefix: str = None,
     ):
         """
         Fits a lens model to a dataset via a non-linear search.
@@ -176,6 +177,9 @@ class AnalysisDataset(AgAnalysisDataset, AnalysisLens):
             be inferred, in which case an Exception is raised before the model-fit begins to inform the user
             of this. This exception is not raised if this input is False, allowing the user to perform the model-fit
             anyway.
+        title_prefix
+            A string that is added before the title of all figures output by visualization, for example to
+            put the name of the dataset and galaxy in the title.
         """
 
         super().__init__(
@@ -183,6 +187,7 @@ class AnalysisDataset(AgAnalysisDataset, AnalysisLens):
             adapt_image_maker=adapt_image_maker,
             cosmology=cosmology,
             settings_inversion=settings_inversion,
+            title_prefix=title_prefix,
         )
 
         AnalysisLens.__init__(

--- a/autolens/analysis/analysis/dataset.py
+++ b/autolens/analysis/analysis/dataset.py
@@ -36,6 +36,7 @@ class AnalysisDataset(AgAnalysisDataset, AnalysisLens):
         cosmology: ag.cosmo.LensingCosmology = ag.cosmo.Planck15(),
         settings_inversion: aa.SettingsInversion = None,
         raise_inversion_positions_likelihood_exception: bool = True,
+        title_prefix: str = None,
     ):
         """
         Fits a lens model to a dataset via a non-linear search.
@@ -74,6 +75,7 @@ class AnalysisDataset(AgAnalysisDataset, AnalysisLens):
             adapt_image_maker=adapt_image_maker,
             cosmology=cosmology,
             settings_inversion=settings_inversion,
+            title_prefix=title_prefix,
         )
 
         AnalysisLens.__init__(

--- a/autolens/imaging/model/visualizer.py
+++ b/autolens/imaging/model/visualizer.py
@@ -29,7 +29,10 @@ class VisualizerImaging(af.Visualizer):
             the imaging data.
         """
 
-        plotter_interface = PlotterInterfaceImaging(image_path=paths.image_path)
+        plotter_interface = PlotterInterfaceImaging(
+            image_path=paths.image_path,
+            title_prefix=analysis.title_prefix
+        )
 
         plotter_interface.imaging(dataset=analysis.dataset)
 
@@ -94,7 +97,10 @@ class VisualizerImaging(af.Visualizer):
             except exc.InversionException:
                 return
 
-        plotter_interface = PlotterInterfaceImaging(image_path=paths.image_path)
+        plotter_interface = PlotterInterfaceImaging(
+            image_path=paths.image_path,
+            title_prefix=analysis.title_prefix
+        )
 
         try:
             plotter_interface.fit_imaging(fit=fit, during_analysis=during_analysis)

--- a/autolens/interferometer/model/analysis.py
+++ b/autolens/interferometer/model/analysis.py
@@ -39,6 +39,7 @@ class AnalysisInterferometer(AnalysisDataset):
         cosmology: ag.cosmo.LensingCosmology = ag.cosmo.Planck15(),
         settings_inversion: aa.SettingsInversion = None,
         raise_inversion_positions_likelihood_exception: bool = True,
+        title_prefix: str = None,
     ):
         """
         Analysis classes are used by PyAutoFit to fit a model to a dataset via a non-linear search.
@@ -76,6 +77,9 @@ class AnalysisInterferometer(AnalysisDataset):
             be inferred, in which case an Exception is raised before the model-fit begins to inform the user
             of this. This exception is not raised if this input is False, allowing the user to perform the model-fit
             anyway.
+        title_prefix
+            A string that is added before the title of all figures output by visualization, for example to
+            put the name of the dataset and galaxy in the title.
         """
         super().__init__(
             dataset=dataset,
@@ -84,6 +88,7 @@ class AnalysisInterferometer(AnalysisDataset):
             cosmology=cosmology,
             settings_inversion=settings_inversion,
             raise_inversion_positions_likelihood_exception=raise_inversion_positions_likelihood_exception,
+            title_prefix=title_prefix,
         )
 
     @property

--- a/autolens/interferometer/model/visualizer.py
+++ b/autolens/interferometer/model/visualizer.py
@@ -28,7 +28,10 @@ class VisualizerInterferometer(af.Visualizer):
             the imaging data.
         """
 
-        plotter_interface = PlotterInterfaceInterferometer(image_path=paths.image_path)
+        plotter_interface = PlotterInterfaceInterferometer(
+            image_path=paths.image_path,
+            title_prefix=analysis.title_prefix
+        )
 
         plotter_interface.interferometer(dataset=analysis.interferometer)
 
@@ -93,7 +96,10 @@ class VisualizerInterferometer(af.Visualizer):
             except exc.InversionException:
                 return
 
-        plotter_interface = PlotterInterfaceInterferometer(image_path=paths.image_path)
+        plotter_interface = PlotterInterfaceInterferometer(
+            image_path=paths.image_path,
+            title_prefix=analysis.title_prefix
+        )
 
         try:
             plotter_interface.fit_interferometer(

--- a/autolens/interferometer/model/visualizer.py
+++ b/autolens/interferometer/model/visualizer.py
@@ -29,8 +29,7 @@ class VisualizerInterferometer(af.Visualizer):
         """
 
         plotter_interface = PlotterInterfaceInterferometer(
-            image_path=paths.image_path,
-            title_prefix=analysis.title_prefix
+            image_path=paths.image_path, title_prefix=analysis.title_prefix
         )
 
         plotter_interface.interferometer(dataset=analysis.interferometer)
@@ -97,8 +96,7 @@ class VisualizerInterferometer(af.Visualizer):
                 return
 
         plotter_interface = PlotterInterfaceInterferometer(
-            image_path=paths.image_path,
-            title_prefix=analysis.title_prefix
+            image_path=paths.image_path, title_prefix=analysis.title_prefix
         )
 
         try:

--- a/autolens/point/model/analysis.py
+++ b/autolens/point/model/analysis.py
@@ -34,6 +34,7 @@ class AnalysisPoint(AgAnalysis, AnalysisLens):
         fit_positions_cls=FitPositionsImagePairRepeat,
         image=None,
         cosmology: ag.cosmo.LensingCosmology = ag.cosmo.Planck15(),
+        title_prefix: str = None,
     ):
         """
         The analysis performed for model-fitting a point-source dataset, for example fitting the point-sources of a
@@ -54,6 +55,9 @@ class AnalysisPoint(AgAnalysis, AnalysisLens):
             visualization.
         cosmology
             The cosmology of the ray-tracing calculation.
+        title_prefix
+            A string that is added before the title of all figures output by visualization, for example to
+            put the name of the dataset and galaxy in the title.
         """
 
         super().__init__(cosmology=cosmology)
@@ -64,7 +68,7 @@ class AnalysisPoint(AgAnalysis, AnalysisLens):
 
         self.solver = solver
         self.fit_positions_cls = fit_positions_cls
-        self.dataset = dataset
+        self.title_prefix = title_prefix
 
     def log_likelihood_function(self, instance):
         """

--- a/docs/overview/overview_7_multi_wavelength.rst
+++ b/docs/overview/overview_7_multi_wavelength.rst
@@ -218,7 +218,7 @@ different intensities.
     for result in result_list:
 
         tracer_plotter = aplt.TracerPlotter(
-            tracer=result.max_log_likelihood_tracer, grid=result.grid
+            tracer=result.max_log_likelihood_tracer, grid=result.grids.uniform
         )
         tracer_plotter.subplot_tracer()
 


### PR DESCRIPTION
Allows you input into all `Analysis` objects a `title_prefix` which is appended before the title of all visualization, so that the name of a dataset or object can be included:

`analysis = al.AnalysisImaging(dataset=dataset, title_prefix="Lens Name")`

![image](https://github.com/user-attachments/assets/71b7ae2a-ffb8-4ae5-9a66-164a7dfab0c1)
