### PR TITLE
Feature/magnification map

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -16,6 +16,7 @@ from autoarray.operators.over_sampling.uniform import OverSamplerUniform  # noqa
 from autoarray.operators.over_sampling.iterate import OverSamplingIterate
 from autoarray.operators.over_sampling.iterate import OverSamplerIterate
 from autoarray.inversion.inversion.dataset_interface import DatasetInterface
+from autoarray.inversion.inversion.mapper_valued import MapperValued
 from autoarray.inversion.pixelization import image_mesh
 from autoarray.inversion.pixelization import mesh
 from autoarray.inversion import regularization as reg
@@ -42,11 +43,16 @@ from autoarray.operators.over_sampling.iterate import OverSamplingIterate
 from autoarray.structures.mesh.rectangular_2d import Mesh2DRectangular
 from autoarray.structures.mesh.voronoi_2d import Mesh2DVoronoi
 from autoarray.structures.mesh.delaunay_2d import Mesh2DDelaunay
+from autoarray.structures.triangles.shape import Circle
+from autoarray.structures.triangles.shape import Triangle
+from autoarray.structures.triangles.shape import Square
+from autoarray.structures.triangles.shape import Polygon
 from autoarray.structures.vectors.uniform import VectorYX2D
 from autoarray.structures.vectors.irregular import VectorYX2DIrregular
 from autoarray.structures.arrays.kernel_2d import Kernel2D
 from autoarray.structures.visibilities import Visibilities
 from autoarray.structures.visibilities import VisibilitiesNoiseMap
+
 
 from autogalaxy import cosmology as cosmo
 from autogalaxy.analysis.adapt_images.adapt_images import AdaptImages
@@ -108,6 +114,7 @@ from .point.fit.positions.source.separations import FitPositionsSource
 from .point.fit.positions.source.max_separation import FitPositionsSourceMaxSeparation
 from .point.model.analysis import AnalysisPoint
 from .point.solver import PointSolver
+from .point.solver.shape_solver import ShapeSolver
 from .quantity.fit_quantity import FitQuantity
 from .quantity.model.analysis import AnalysisQuantity
 from . import exc

--- a/autolens/analysis/result.py
+++ b/autolens/analysis/result.py
@@ -235,7 +235,6 @@ class ResultDataset(Result):
         """
         if self.max_log_likelihood_fit.inversion is not None:
             if self.max_log_likelihood_fit.inversion.has(cls=aa.AbstractMapper):
-
                 inversion = self.max_log_likelihood_fit.inversion
                 mapper = inversion.cls_list_from(cls=aa.AbstractMapper)[0]
 

--- a/autolens/analysis/result.py
+++ b/autolens/analysis/result.py
@@ -235,6 +235,13 @@ class ResultDataset(Result):
         """
         if self.max_log_likelihood_fit.inversion is not None:
             if self.max_log_likelihood_fit.inversion.has(cls=aa.AbstractMapper):
-                return (
-                    self.max_log_likelihood_fit.inversion.brightest_pixel_centre_list[0]
+
+                inversion = self.max_log_likelihood_fit.inversion
+                mapper = inversion.cls_list_from(cls=aa.AbstractMapper)[0]
+
+                mapper_valued = aa.MapperValued(
+                    values=inversion.reconstruction_dict[mapper],
+                    mapper=mapper,
                 )
+
+                return mapper_valued.max_pixel_centre

--- a/test_autolens/analysis/test_result.py
+++ b/test_autolens/analysis/test_result.py
@@ -137,11 +137,17 @@ def test__source_plane_inversion_centre(analysis_imaging_7x7):
         samples_summary=samples_summary, analysis=analysis_imaging_7x7
     )
 
+    inversion = result.max_log_likelihood_fit.inversion
+    mapper = inversion.cls_list_from(cls=al.AbstractMapper)[0]
+
+    mapper_valued = al.MapperValued(
+        values=inversion.reconstruction_dict[mapper],
+        mapper=mapper,
+    )
+
     assert (
         result.source_plane_inversion_centre.in_list[0]
-        == result.max_log_likelihood_fit.inversion.brightest_pixel_centre_list[
-            0
-        ].in_list[0]
+        == mapper_valued.max_pixel_centre.in_list[0]
     )
 
     lens = al.Galaxy(redshift=0.5, light=al.lp.SersicSph(intensity=1.0))


### PR DESCRIPTION
Refactors the inversion module to make it simpler to compute magnifications for PyAutoLens.

See this docstring for a run throuhg of the main changes:

The pixelized source reconstruction output by an Inversion is often on an irregular grid (e.g. a
Voronoi triangulation or Voronoi mesh), making it difficult to manipulate and inspect after the lens modeling has
completed.

Internally, the inversion stores a Mapper object to perform these calculations, which effectively maps pixels
between the image-plane and source-plane.

After an inversion is complete, it has computed values which can be paired with the Mapper to perform calculations,
most notably the reconstruction, which is the reconstructed source pixel values.

By inputting the inversions's mapper and a set of values (e.g. the reconstruction) into a MapperValued object, we
are provided with all the functionality we need to perform calculations on the source reconstruction.

We set up the MapperValued object below, and illustrate how we can use it to interpolate the source reconstruction
to a uniform grid of values, perform magnification calculations and other tasks.