### PR TITLE
clumps removed

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -30,6 +30,7 @@ from autoarray.inversion.pixelization.mappers.abstract import AbstractMapper
 from autoarray.inversion.pixelization.mappers.mapper_grids import MapperGrids
 from autoarray.inversion.pixelization.mappers.factory import mapper_from as Mapper
 from autoarray.inversion.pixelization.border_relocator import BorderRelocator
+from autoarray.operators.over_sampling.grid_oversampled import Grid2DOverSampled
 from autoarray.operators.transformer import TransformerDFT
 from autoarray.operators.transformer import TransformerNUFFT
 from autoarray.structures.arrays.uniform_1d import Array1D
@@ -62,8 +63,6 @@ from autogalaxy.gui.scribbler import Scribbler
 from autogalaxy.galaxy.galaxy import Galaxy
 from autogalaxy.galaxy.galaxies import Galaxies
 from autogalaxy.galaxy.redshift import Redshift
-from autogalaxy.analysis.clump_model import ClumpModel
-from autogalaxy.analysis.clump_model import ClumpModelDisabled
 
 from autogalaxy.quantity.dataset_quantity import DatasetQuantity
 from autogalaxy.profiles.geometry_profiles import EllProfile

--- a/autolens/lens/sensitivity.py
+++ b/autolens/lens/sensitivity.py
@@ -85,7 +85,15 @@ class SubhaloSensitivityResult(SensitivityResult):
         """
         values_reshaped = [value for values in values.native for value in values]
 
-        pixel_scales = abs(self.x[0] - self.x[1])
+        pixel_scale_list = []
+
+        for i in range(len(values_reshaped) - 1):
+
+            pixel_scale = abs(self.x[i] - self.x[i+1])
+            if pixel_scale > 0.0:
+                pixel_scale_list.append(pixel_scale)
+
+        pixel_scales = np.min(pixel_scale_list)
 
         return aa.Array2D.from_yx_and_values(
             y=self.y,

--- a/docs/howtolens/chapter_1_introduction.rst
+++ b/docs/howtolens/chapter_1_introduction.rst
@@ -11,10 +11,10 @@ The chapter contains the following tutorials:
 - Setting up **PyAutoLens**'s visualization library.
 
 `Tutorial 1: Grids And Galaxies <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_1_grids_and_galaxies.ipynb>`_
-- Using grids of (y,x) coordinates with galaxies made up of light and mass profiles.
+- Using grids of (y,x) coordinates with galaxies made up of light profiles.
 
 `Tutorial 2: Ray Tracing <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_2_ray_tracing.ipynb>`_
-- Using Grids and galaxies to perform strong lens ray-tracing!
+- Using grids, galaxies and mass profiles to perform strong lens ray-tracing.
 
 `Tutorial 3: More Ray Tracing <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_3_more_ray_tracing.ipynb>`_
 - Advanced strong lens ray-tracing.

--- a/test_autolens/analysis/analysis/test_analysis_lens.py
+++ b/test_autolens/analysis/analysis/test_analysis_lens.py
@@ -18,7 +18,7 @@ def test__tracer_for_instance(analysis_imaging_7x7):
             source=al.Galaxy(redshift=1.0),
         )
         + af.Collection(
-            clump=al.Galaxy(
+            extra_galaxyp=al.Galaxy(
                 redshift=0.5,
                 light=al.lp.SersicSph(intensity=0.1),
                 mass=al.mp.IsothermalSph(einstein_radius=0.2),

--- a/test_autolens/analysis/test_analysis.py
+++ b/test_autolens/analysis/test_analysis.py
@@ -24,7 +24,7 @@ def test__tracer_for_instance(analysis_imaging_7x7):
             source=al.Galaxy(redshift=1.0),
         )
         + af.Collection(
-            clump=al.Galaxy(
+            extra_galaxy=al.Galaxy(
                 redshift=0.5,
                 light=al.lp.SersicSph(intensity=0.1),
                 mass=al.mp.IsothermalSph(einstein_radius=0.2),


### PR DESCRIPTION
Removes the clump API from the source code, which was an unecessary layer for creating models with extra galaxies that is now replaced with high level documentation to teach a user the modeling API required.