### PR TITLE
feature/coordinate array integration

### DIFF
--- a/autolens/point/solver/point_solver.py
+++ b/autolens/point/solver/point_solver.py
@@ -85,7 +85,7 @@ class PointSolver(AbstractSolver):
         for mean in filtered_means:
             if any(
                 np.linalg.norm(np.array(mean) - np.array(other))
-                <= self.pixel_scale_precision
+                <= self.pixel_scale_precision / 2
                 for other in filtered_close
             ):
                 continue

--- a/autolens/point/solver/point_solver.py
+++ b/autolens/point/solver/point_solver.py
@@ -23,7 +23,6 @@ class PointSolver(AbstractSolver):
         tracer: OperateDeflections,
         source_plane_coordinate: Tuple[float, float],
         source_plane_redshift: Optional[float] = None,
-        neighbor_degree: int = 0,
     ) -> aa.Grid2DIrregular:
         """
         Solve for the image plane coordinates that are traced to the source plane coordinate.
@@ -37,9 +36,6 @@ class PointSolver(AbstractSolver):
 
         Parameters
         ----------
-        neighbor_degree
-            The number of times recursively add neighbors for the triangles that contain
-            the source plane coordinate.
         source_plane_coordinate
             The source plane coordinate to trace to the image plane.
         tracer
@@ -56,9 +52,6 @@ class PointSolver(AbstractSolver):
             shape=Point(*source_plane_coordinate),
             source_plane_redshift=source_plane_redshift,
         )
-
-        for _ in range(neighbor_degree):
-            kept_triangles = kept_triangles.neighborhood()
 
         filtered_means = self._filter_low_magnification(
             tracer=tracer, points=kept_triangles.means

--- a/autolens/point/solver/point_solver.py
+++ b/autolens/point/solver/point_solver.py
@@ -23,7 +23,7 @@ class PointSolver(AbstractSolver):
         tracer: OperateDeflections,
         source_plane_coordinate: Tuple[float, float],
         source_plane_redshift: Optional[float] = None,
-        neighbor_order: int = 0,
+        neighbor_degree: int = 0,
     ) -> aa.Grid2DIrregular:
         """
         Solve for the image plane coordinates that are traced to the source plane coordinate.
@@ -37,7 +37,7 @@ class PointSolver(AbstractSolver):
 
         Parameters
         ----------
-        neighbor_order
+        neighbor_degree
             The number of times recursively add neighbors for the triangles that contain
             the source plane coordinate.
         source_plane_coordinate
@@ -57,7 +57,7 @@ class PointSolver(AbstractSolver):
             source_plane_redshift=source_plane_redshift,
         )
 
-        for _ in range(neighbor_order):
+        for _ in range(neighbor_degree):
             kept_triangles = kept_triangles.neighborhood()
 
         filtered_means = self._filter_low_magnification(

--- a/autolens/point/solver/point_solver.py
+++ b/autolens/point/solver/point_solver.py
@@ -23,12 +23,13 @@ class PointSolver(AbstractSolver):
         tracer: OperateDeflections,
         source_plane_coordinate: Tuple[float, float],
         source_plane_redshift: Optional[float] = None,
+        neighbor_order: int = 0,
     ) -> aa.Grid2DIrregular:
         """
         Solve for the image plane coordinates that are traced to the source plane coordinate.
 
         This is done by tiling the image plane with triangles and checking if the source plane coordinate is contained
-        within the triangle. The triangles are subsampled to increase the resolution with only the triangles that
+        within the triangle. The triangles are sub-sampled to increase the resolution with only the triangles that
         contain the source plane coordinate and their neighbours being kept.
 
         The means of the triangles  are then filtered to keep only those with an absolute magnification above the
@@ -36,6 +37,9 @@ class PointSolver(AbstractSolver):
 
         Parameters
         ----------
+        neighbor_order
+            The number of times recursively add neighbors for the triangles that contain
+            the source plane coordinate.
         source_plane_coordinate
             The source plane coordinate to trace to the image plane.
         tracer
@@ -52,6 +56,10 @@ class PointSolver(AbstractSolver):
             shape=Point(*source_plane_coordinate),
             source_plane_redshift=source_plane_redshift,
         )
+
+        for _ in range(neighbor_order):
+            kept_triangles = kept_triangles.neighborhood()
+
         filtered_means = self._filter_low_magnification(
             tracer=tracer, points=kept_triangles.means
         )

--- a/autolens/point/solver/shape_solver.py
+++ b/autolens/point/solver/shape_solver.py
@@ -41,6 +41,7 @@ class AbstractSolver:
         initial_triangles: AbstractTriangles,
         pixel_scale_precision: float,
         magnification_threshold=0.1,
+        neighbor_degree: int = 1,
     ):
         """
         Determine the image plane coordinates that are traced to be a source plane coordinate.
@@ -51,12 +52,16 @@ class AbstractSolver:
 
         Parameters
         ----------
+        neighbor_degree
+            The number of times recursively add neighbors for the triangles that contain
+            the source plane coordinate.
         pixel_scale_precision
             The target pixel scale of the image grid.
         """
         self.scale = scale
         self.pixel_scale_precision = pixel_scale_precision
         self.magnification_threshold = magnification_threshold
+        self.neighbor_degree = neighbor_degree
 
         self.initial_triangles = initial_triangles
 
@@ -279,7 +284,10 @@ class AbstractSolver:
                 source_plane_redshift=source_plane_redshift,
                 shape=shape,
             )
-            neighbourhood = kept_triangles.neighborhood()
+            neighbourhood = kept_triangles
+            for _ in range(self.neighbor_degree):
+                neighbourhood = neighbourhood.neighborhood()
+
             up_sampled = neighbourhood.up_sample()
 
             yield Step(

--- a/autolens/point/solver/shape_solver.py
+++ b/autolens/point/solver/shape_solver.py
@@ -4,6 +4,7 @@ import math
 from typing import Tuple, List, Iterator, Type, Optional
 
 import autoarray as aa
+from autoarray.structures.triangles.coordinate_array import CoordinateArrayTriangles
 
 from autoarray.structures.triangles.shape import Shape
 from autofit.jax_wrapper import jit, use_jax, numpy as np, register_pytree_node_class
@@ -66,7 +67,7 @@ class AbstractSolver:
         grid: aa.Grid2D,
         pixel_scale_precision: float,
         magnification_threshold=0.1,
-        array_triangles_cls: Type[AbstractTriangles] = ArrayTriangles,
+        array_triangles_cls: Type[AbstractTriangles] = CoordinateArrayTriangles,
         max_containing_size=MAX_CONTAINING_SIZE,
     ):
         """

--- a/autolens/point/visualise.py
+++ b/autolens/point/visualise.py
@@ -22,3 +22,16 @@ def visualise(step: Step):
     plt.title(f"Step {step.number}")
     plt.gca().set_aspect("equal", adjustable="box")
     plt.show()
+
+
+def plot_triangles(triangles, color="black"):
+    plt.figure(figsize=(8, 8))
+    for triangle in triangles:
+        triangle = np.append(triangle, [triangle[0]], axis=0)
+        plt.plot(triangle[:, 0], triangle[:, 1], "o-", color=color)
+
+    plt.xlabel("X")
+    plt.ylabel("Y")
+    plt.title(f"Triangles")
+    plt.gca().set_aspect("equal", adjustable="box")
+    plt.show()

--- a/test_autolens/point/triangles/test_extended.py
+++ b/test_autolens/point/triangles/test_extended.py
@@ -1,5 +1,6 @@
 import pytest
 
+from autoarray.structures.triangles.coordinate_array import CoordinateArrayTriangles
 from autoarray.structures.triangles.shape import Circle
 from autolens.mock import NullTracer
 from autolens.point.solver.shape_solver import ShapeSolver
@@ -9,7 +10,8 @@ from autolens.point.solver.shape_solver import ShapeSolver
 def solver(grid):
     return ShapeSolver.for_grid(
         grid=grid,
-        pixel_scale_precision=0.01,
+        pixel_scale_precision=0.001,
+        array_triangles_cls=CoordinateArrayTriangles,
     )
 
 
@@ -19,6 +21,6 @@ def test_solver_basic(solver):
         shape=Circle(
             0.0,
             0.0,
-            radius=0.01,
+            radius=0.1,
         ),
-    ) == pytest.approx(1.0, abs=0.01)
+    ) == pytest.approx(1.0, abs=0.1)

--- a/test_autolens/point/triangles/test_solver.py
+++ b/test_autolens/point/triangles/test_solver.py
@@ -4,12 +4,8 @@ import pytest
 
 import autolens as al
 import autogalaxy as ag
-from autoarray.structures.triangles.array import ArrayTriangles
-from autoarray.structures.triangles.coordinate_array import CoordinateArrayTriangles
-from autoarray.structures.triangles.shape import Point
 from autolens.mock import NullTracer
 from autolens.point.solver import PointSolver
-from autolens.point.visualise import visualise
 
 
 @pytest.fixture
@@ -17,7 +13,6 @@ def solver(grid):
     return PointSolver.for_grid(
         grid=grid,
         pixel_scale_precision=0.01,
-        array_triangles_cls=CoordinateArrayTriangles,
     )
 
 
@@ -66,7 +61,6 @@ def test_trivial(
     solver = PointSolver.for_grid(
         grid=grid,
         pixel_scale_precision=0.01,
-        array_triangles_cls=CoordinateArrayTriangles,
     )
     coordinates = solver.solve(
         tracer=NullTracer(),
@@ -80,7 +74,6 @@ def test_real_example(grid, tracer):
     solver = PointSolver.for_grid(
         grid=grid,
         pixel_scale_precision=0.001,
-        array_triangles_cls=CoordinateArrayTriangles,
     )
 
     result = solver.solve(tracer=tracer, source_plane_coordinate=(0.07, 0.07))

--- a/test_autolens/point/triangles/test_solver.py
+++ b/test_autolens/point/triangles/test_solver.py
@@ -82,7 +82,7 @@ def test_real_example(grid, tracer):
 
 
 @pytest.mark.parametrize(
-    "neighbor_order, expected",
+    "neighbor_degree, expected",
     [
         (0, 1),
         (1, 4),
@@ -91,7 +91,7 @@ def test_real_example(grid, tracer):
 )
 def test_neighbor_order(
     solver,
-    neighbor_order,
+    neighbor_degree,
     expected,
 ):
     assert (
@@ -99,7 +99,7 @@ def test_neighbor_order(
             solver.solve(
                 NullTracer(),
                 source_plane_coordinate=(0.0, 0.0),
-                neighbor_order=neighbor_order,
+                neighbor_order=neighbor_degree,
             )
         )
         == expected

--- a/test_autolens/point/triangles/test_solver.py
+++ b/test_autolens/point/triangles/test_solver.py
@@ -79,3 +79,28 @@ def test_real_example(grid, tracer):
     result = solver.solve(tracer=tracer, source_plane_coordinate=(0.07, 0.07))
 
     assert len(result) == 5
+
+
+@pytest.mark.parametrize(
+    "neighbor_order, expected",
+    [
+        (0, 1),
+        (1, 4),
+        (2, 10),
+    ],
+)
+def test_neighbor_order(
+    solver,
+    neighbor_order,
+    expected,
+):
+    assert (
+        len(
+            solver.solve(
+                NullTracer(),
+                source_plane_coordinate=(0.0, 0.0),
+                neighbor_order=neighbor_order,
+            )
+        )
+        == expected
+    )

--- a/test_autolens/point/triangles/test_solver.py
+++ b/test_autolens/point/triangles/test_solver.py
@@ -99,7 +99,7 @@ def test_neighbor_order(
             solver.solve(
                 NullTracer(),
                 source_plane_coordinate=(0.0, 0.0),
-                neighbor_order=neighbor_degree,
+                neighbor_degree=neighbor_degree,
             )
         )
         == expected

--- a/test_autolens/point/triangles/test_solver.py
+++ b/test_autolens/point/triangles/test_solver.py
@@ -6,8 +6,10 @@ import autolens as al
 import autogalaxy as ag
 from autoarray.structures.triangles.array import ArrayTriangles
 from autoarray.structures.triangles.coordinate_array import CoordinateArrayTriangles
+from autoarray.structures.triangles.shape import Point
 from autolens.mock import NullTracer
 from autolens.point.solver import PointSolver
+from autolens.point.visualise import visualise
 
 
 @pytest.fixture
@@ -15,6 +17,7 @@ def solver(grid):
     return PointSolver.for_grid(
         grid=grid,
         pixel_scale_precision=0.01,
+        array_triangles_cls=CoordinateArrayTriangles,
     )
 
 
@@ -77,8 +80,9 @@ def test_real_example(grid, tracer):
     solver = PointSolver.for_grid(
         grid=grid,
         pixel_scale_precision=0.001,
-        array_triangles_cls=ArrayTriangles,
+        array_triangles_cls=CoordinateArrayTriangles,
     )
+
     result = solver.solve(tracer=tracer, source_plane_coordinate=(0.07, 0.07))
 
     assert len(result) == 5

--- a/test_autolens/point/triangles/test_solver.py
+++ b/test_autolens/point/triangles/test_solver.py
@@ -79,28 +79,3 @@ def test_real_example(grid, tracer):
     result = solver.solve(tracer=tracer, source_plane_coordinate=(0.07, 0.07))
 
     assert len(result) == 5
-
-
-@pytest.mark.parametrize(
-    "neighbor_degree, expected",
-    [
-        (0, 1),
-        (1, 4),
-        (2, 10),
-    ],
-)
-def test_neighbor_order(
-    solver,
-    neighbor_degree,
-    expected,
-):
-    assert (
-        len(
-            solver.solve(
-                NullTracer(),
-                source_plane_coordinate=(0.0, 0.0),
-                neighbor_degree=neighbor_degree,
-            )
-        )
-        == expected
-    )

--- a/test_autolens/point/triangles/test_solver.py
+++ b/test_autolens/point/triangles/test_solver.py
@@ -5,6 +5,7 @@ import pytest
 import autolens as al
 import autogalaxy as ag
 from autoarray.structures.triangles.array import ArrayTriangles
+from autoarray.structures.triangles.coordinate_array import CoordinateArrayTriangles
 from autolens.mock import NullTracer
 from autolens.point.solver import PointSolver
 
@@ -62,13 +63,14 @@ def test_trivial(
     solver = PointSolver.for_grid(
         grid=grid,
         pixel_scale_precision=0.01,
-        array_triangles_cls=ArrayTriangles,
+        array_triangles_cls=CoordinateArrayTriangles,
     )
-    (coordinates,) = solver.solve(
+    coordinates = solver.solve(
         tracer=NullTracer(),
         source_plane_coordinate=source_plane_coordinate,
     )
-    assert coordinates == pytest.approx(source_plane_coordinate, abs=1.0e-1)
+
+    assert coordinates[0] == pytest.approx(source_plane_coordinate, abs=1.0e-1)
 
 
 def test_real_example(grid, tracer):

--- a/test_autolens/point/triangles/test_solver_jax.py
+++ b/test_autolens/point/triangles/test_solver_jax.py
@@ -6,7 +6,7 @@ import pytest
 import autogalaxy as ag
 import autofit as af
 import numpy as np
-from autolens import PointSolver
+from autolens import PointSolver, Tracer
 
 try:
     from autoarray.structures.triangles.jax_array import ArrayTriangles
@@ -33,14 +33,19 @@ def solver(grid):
 
 
 def test_solver(solver):
-    tracer = ag.mp.Isothermal(
+    mass_profile = ag.mp.Isothermal(
         centre=(0.0, 0.0),
         einstein_radius=1.0,
     )
-    assert solver.solve(
+    tracer = Tracer(
+        galaxies=[ag.Galaxy(redshift=0.5, mass=mass_profile)],
+    )
+    result = solver.solve(
         tracer,
         source_plane_coordinate=(0.0, 0.0),
     )
+    print(result)
+    assert result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #314

Optionally specify neighbor_degree to include immediate neighbors, neighbors of neighbors etc.

```python

# Immediate neigbors
result = solver.solve(
    tracer,
    source_plane_coordinate=(0.0, 0.0),
    neighbor_degree=1,
)

# Neighbors of neigbors
result = solver.solve(
    tracer,
    source_plane_coordinate=(0.0, 0.0),
    neighbor_degree=2,
)
