### PR TITLE
Feature/disable noise

### DIFF
--- a/autolens/imaging/simulator.py
+++ b/autolens/imaging/simulator.py
@@ -9,21 +9,30 @@ class SimulatorImaging(aa.SimulatorImaging):
 
     def via_tracer_from(self, tracer : Tracer, grid : aa.type.Grid2DLike) -> aa.Imaging:
         """
-        Simulate an `Imaging` dataset from an input tracer and grid.
+        Simulate an `Imaging` dataset from an input `Tracer` object and a 2D grid of (y,x) coordinates.
 
-        The tracer is used to perform ray-tracing and generate the image of the strong lens galaxies (e.g.
-        the lens light, lensed source light, etc) which is simulated.
+        The mass profiles of each galaxy in the tracer are used to perform ray-tracing of the input 2D grid and
+        their light profiles are used to generate the image of the galaxies which are simulated.
 
         The steps of the `SimulatorImaging` simulation process (e.g. PSF convolution, noise addition) are
-        described in the `SimulatorImaging` `__init__` method docstring.
+        described in the `SimulatorImaging` `__init__` method docstring, found in the PyAutoArray project.
+
+        If one of more galaxy light profiles are a `LightProfileSNR` object, the `intensity` of the light profile is
+        automatically set such that the signal-to-noise ratio of the light profile is equal to its input
+        `signal_to_noise_ratio` value.
+
+        For example, if a `LightProfileSNR` object has a `signal_to_noise_ratio` of 5.0, the intensity of the light
+        profile is set such that the peak surface brightness of the profile is 5.0 times the background noise level of
+        the image.
 
         Parameters
         ----------
         tracer
             The tracer, which describes the ray-tracing and strong lens configuration used to simulate the imaging
-            dataset.
+            dataset as well as the light profiles of the galaxies used to simulate the image of the galaxies.
         grid
-            The image-plane grid which the image of the strong lens is generated on.
+            The 2D grid of (y,x) coordinates which the mass profiles of the galaxies in the tracer are ray-traced using
+            in order to generate the image of the galaxies via their light profiles.
         """
 
         tracer.set_snr_of_snr_light_profiles(
@@ -44,13 +53,22 @@ class SimulatorImaging(aa.SimulatorImaging):
 
     def via_galaxies_from(self, galaxies : List[ag.Galaxy], grid : aa.type.Grid2DLike) -> aa.Imaging:
         """
-        Simulate an `Imaging` dataset from an input list of galaxies and grid.
+        Simulate an `Imaging` dataset from an input list of `Galaxy` objects and a 2D grid of (y,x) coordinates.
 
-        The galaxies are used to create a tracer, which performs ray-tracing and generate the image of the strong lens
-        galaxies (e.g. the lens light, lensed source light, etc) which is simulated.
+        The galaxies are used to create a `Tracer`. The mass profiles of each galaxy in the tracer are used to
+        perform ray-tracing of the input 2D grid and their light profiles are used to generate the image of the
+        galaxies which are simulated.
 
         The steps of the `SimulatorImaging` simulation process (e.g. PSF convolution, noise addition) are
         described in the `SimulatorImaging` `__init__` method docstring.
+
+        If one of more galaxy light profiles are a `LightProfileSNR` object, the `intensity` of the light profile is
+        automatically set such that the signal-to-noise ratio of the light profile is equal to its input
+        `signal_to_noise_ratio` value.
+
+        For example, if a `LightProfileSNR` object has a `signal_to_noise_ratio` of 5.0, the intensity of the light
+        profile is set such that the peak surface brightness of the profile is 5.0 times the background noise level of
+        the image.
 
         Parameters
         ----------
@@ -58,7 +76,7 @@ class SimulatorImaging(aa.SimulatorImaging):
             The galaxies used to create the tracer, which describes the ray-tracing and strong lens configuration
             used to simulate the imaging dataset.
         grid
-            The image-plane grid which the image of the strong lens is generated on.
+            The image-plane 2D grid of (y,x) coordinates grid which the image of the strong lens is generated on.
         """
 
         tracer = Tracer(galaxies=galaxies)
@@ -87,7 +105,7 @@ class SimulatorImaging(aa.SimulatorImaging):
             The galaxies used to create the tracer, which describes the ray-tracing and strong lens configuration
             used to simulate the imaging dataset.
         grid
-            The image-plane grid which the image of the strong lens is generated on.
+            The image-plane 2D grid of (y,x) coordinates grid which the image of the strong lens is generated on.
         """
         grid = aa.Grid2D.uniform(
             shape_native=deflections.shape_native,
@@ -105,10 +123,10 @@ class SimulatorImaging(aa.SimulatorImaging):
         Simulate an `Imaging` dataset from an input image of a source galaxy.
 
         This input image is on a uniform and regular 2D array, meaning it can simulate the source's irregular
-        and assymetric source galaxy morphological features.
+        and asymmetric source galaxy morphological features.
 
         The typical use case is inputting the image of an irregular galaxy in the source-plane (whose values are
-        on a uniform array) and using this function computing the lensed image of this source galaxy.
+        on a uniform array) and using this function to compute the lensed image of this source galaxy.
 
         The tracer is used to perform ray-tracing and generate the image of the strong lens galaxies (e.g.
         the lens light, lensed source light, etc) which is simulated.
@@ -125,7 +143,7 @@ class SimulatorImaging(aa.SimulatorImaging):
             The tracer, which describes the ray-tracing and strong lens configuration used to simulate the imaging
             dataset.
         grid
-            The image-plane grid which the image of the strong lens is generated on.
+            The image-plane 2D grid of (y,x) coordinates grid which the image of the strong lens is generated on.
         source_image
             The image of the source-plane and source galaxy which is interpolated to compute the lensed image.
         """

--- a/autolens/interferometer/simulator.py
+++ b/autolens/interferometer/simulator.py
@@ -18,7 +18,7 @@ class SimulatorInterferometer(aa.SimulatorInterferometer):
             An arrays representing the effective exposure time of each pixel.
         psf: PSF
             An arrays describing the PSF the simulated image is blurred with.
-        add_poisson_noise: Bool
+        add_poisson_noise_to_data: Bool
             If `True` poisson noise_maps is simulated and added to the image, based on the total counts in each image
             pixel
         noise_seed: int

--- a/docs/overview/overview_1_start_here.rst
+++ b/docs/overview/overview_1_start_here.rst
@@ -361,7 +361,7 @@ object.
         exposure_time=300.0,
         background_sky_level=1.0,
         psf=al.Kernel2D.from_gaussian(shape_native=(11, 11), sigma=0.1, pixel_scales=0.05),
-        add_poisson_noise=True,
+        add_poisson_noise_to_data=True,
     )
 
 Once we have a simulator, we can use it to create an imaging dataset which consists of an image, noise-map and 

--- a/test_autolens/imaging/test_simulate_and_fit_imaging.py
+++ b/test_autolens/imaging/test_simulate_and_fit_imaging.py
@@ -25,7 +25,7 @@ def test__perfect_fit__chi_squared_0():
     )
     tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
 
-    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise=False)
+    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise_to_data=False)
 
     dataset = dataset.via_tracer_from(tracer=tracer, grid=grid)
     dataset.noise_map = al.Array2D.ones(
@@ -99,7 +99,7 @@ def test__perfect_fit__chi_squared_0__use_grid_iterate_to_simulate_and_fit():
     )
     tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
 
-    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise=False)
+    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise_to_data=False)
 
     dataset = dataset.via_tracer_from(tracer=tracer, grid=grid)
     dataset.noise_map = al.Array2D.ones(
@@ -217,7 +217,7 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_agree_with_standa
     )
     tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
 
-    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise=False)
+    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise_to_data=False)
 
     dataset = dataset.via_tracer_from(tracer=tracer, grid=grid)
     dataset.sub_size = 1
@@ -324,7 +324,7 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_and_pixelization(
     )
     tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
 
-    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise=False)
+    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise_to_data=False)
 
     dataset = dataset.via_tracer_from(tracer=tracer, grid=grid)
     dataset.sub_size = 1
@@ -477,7 +477,7 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_and_pixelization_
     )
     tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
 
-    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise=False)
+    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise_to_data=False)
 
     dataset = dataset.via_tracer_from(tracer=tracer, grid=grid)
     dataset.noise_map = al.Array2D.ones(
@@ -621,7 +621,7 @@ def test__simulate_imaging_data_and_fit__complex_fit_compare_mapping_matrix_w_ti
     source_1 = al.Galaxy(redshift=0.5, bulge=al.lp.Sersic(centre=(0.3, 0.3)))
     tracer = al.Tracer(galaxies=[lens_0, lens_1, lens_2, source_0, source_1])
 
-    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise=False)
+    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise_to_data=False)
 
     dataset = dataset.via_tracer_from(tracer=tracer, grid=grid)
     dataset.sub_size = 2
@@ -759,7 +759,7 @@ def test__perfect_fit__chi_squared_0__non_uniform_over_sampling():
     )
     tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
 
-    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise=False)
+    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise_to_data=False)
 
     dataset = dataset.via_tracer_from(tracer=tracer, grid=grid)
     dataset.noise_map = al.Array2D.ones(
@@ -847,7 +847,7 @@ def test__fit_figure_of_merit__mge_mass_model(masked_imaging_7x7, masked_imaging
     )
     tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
 
-    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise=False)
+    dataset = al.SimulatorImaging(exposure_time=300.0, psf=psf, add_poisson_noise_to_data=False)
 
     dataset = dataset.via_tracer_from(tracer=tracer, grid=grid)
     dataset.noise_map = al.Array2D.ones(


### PR DESCRIPTION
More customization of the `SimulatorImaging` object so that the `data` can be simulated without Poisson noise but the `noise_map` still include values as if it were included, and visa versa.