### PR TITLE
feature/inversion_noise_map

### DIFF
--- a/autolens/config/visualize/plots.yaml
+++ b/autolens/config/visualize/plots.yaml
@@ -55,7 +55,7 @@
     all_at_end_png: true                     # Plot all individual plots listed below as .png (even if False)?
     all_at_end_fits: true                    # Plot all individual plots listed below as .fits (even if False)?
     all_at_end_pdf: false                    # Plot all individual plots listed below as publication-quality .pdf (even if False)?
-    errors: false
+    reconstruction_noise_map: false
     reconstructed_image: false
     reconstruction: false
     regularization_weights: false

--- a/autolens/imaging/plot/fit_imaging_plotters.py
+++ b/autolens/imaging/plot/fit_imaging_plotters.py
@@ -148,7 +148,7 @@ class FitImagingPlotter(Plotter):
         subtracted_image: bool = False,
         model_image: bool = False,
         plane_image: bool = False,
-        plane_errors: bool = False,
+        plane_noise_map: bool = False,
         plane_signal_to_noise_map: bool = False,
         use_source_vmax: bool = False,
         zoom_to_brightest: bool = True,
@@ -180,12 +180,12 @@ class FitImagingPlotter(Plotter):
             Whether to make a 2D plot (via `imshow`) of the image of a plane in its source-plane (e.g. unlensed).
             Depending on how the fit is performed, this could either be an image of light profiles of the reconstruction
             of an `Inversion`.
-        plane_errors
-            Whether to make a 2D plot (via `imshow`) of the errors of a plane in its source-plane, where the
-            errors can only be computed when a pixelized source reconstruction is performed and they correspond to
-            the errors in each reconstructed pixel as given by the inverse curvature matrix.
+        plane_noise_map
+            Whether to make a 2D plot of the noise-map of a plane in its source-plane, where the
+            noise map can only be computed when a pixelized source reconstruction is performed and they correspond to
+            the noise map in each reconstructed pixel as given by the inverse curvature matrix.
         plane_signal_to_noise_map
-            Whether to make a 2D plot (via `imshow`) of the signal-to-noise map of a plane in its source-plane,
+            Whether to make a 2D plot of the signal-to-noise map of a plane in its source-plane,
             where the signal-to-noise map values can only be computed when a pixelized source reconstruction and they
             are the ratio of reconstructed flux to error in each pixel.
         use_source_vmax
@@ -312,7 +312,7 @@ class FitImagingPlotter(Plotter):
                 except KeyError:
                     pass
 
-            if plane_errors:
+            if plane_noise_map:
 
                 if self.tracer.planes[plane_index].has(cls=aa.Pixelization):
 
@@ -322,7 +322,7 @@ class FitImagingPlotter(Plotter):
 
                     inversion_plotter.figures_2d_of_pixelization(
                         pixelization_index=0,
-                        errors=True,
+                        reconstruction_noise_map=True,
                         zoom_to_brightest=zoom_to_brightest,
                         interpolate_to_uniform=interpolate_to_uniform
                     )

--- a/autolens/interferometer/plot/fit_interferometer_plotters.py
+++ b/autolens/interferometer/plot/fit_interferometer_plotters.py
@@ -375,7 +375,7 @@ class FitInterferometerPlotter(Plotter):
         self,
         plane_index: Optional[int] = None,
         plane_image: bool = False,
-        plane_errors: bool = False,
+        plane_noise_map: bool = False,
         plane_signal_to_noise_map: bool = False,
         zoom_to_brightest: bool = True,
         interpolate_to_uniform: bool = False,
@@ -398,12 +398,12 @@ class FitInterferometerPlotter(Plotter):
             Whether to make a 2D plot (via `imshow`) of the image of a plane in its source-plane (e.g. unlensed).
             Depending on how the fit is performed, this could either be an image of light profiles of the reconstruction
             of an `Inversion`.
-        plane_errors
-            Whether to make a 2D plot (via `imshow`) of the errors of a plane in its source-plane, where the
-            errors can only be computed when a pixelized source reconstruction is performed and they correspond to
-            the errors in each reconstructed pixel as given by the inverse curvature matrix.
+        plane_noise_map
+            Whether to make a 2D plot of the noise-map of a plane in its source-plane, where the
+            noise map can only be computed when a pixelized source reconstruction is performed and they correspond to
+            the noise map in each reconstructed pixel as given by the inverse curvature matrix.
         plane_signal_to_noise_map
-            Whether to make a 2D plot (via `imshow`) of the signal-to-noise map of a plane in its source-plane,
+            Whether to make a 2D plot of the signal-to-noise map of a plane in its source-plane,
             where the signal-to-noise map values can only be computed when a pixelized source reconstruction and they
             are the ratio of reconstructed flux to error in each pixel.
         zoom_to_brightest
@@ -430,7 +430,7 @@ class FitInterferometerPlotter(Plotter):
                     interpolate_to_uniform=interpolate_to_uniform,
                 )
 
-        if plane_errors:
+        if plane_noise_map:
             if self.tracer.planes[plane_index].has(cls=aa.Pixelization):
                 inversion_plotter = self.inversion_plotter_of_plane(
                     plane_index=plane_index
@@ -438,7 +438,7 @@ class FitInterferometerPlotter(Plotter):
 
                 inversion_plotter.figures_2d_of_pixelization(
                     pixelization_index=0,
-                    errors=True,
+                    reconstruction_noise_map=True,
                     zoom_to_brightest=zoom_to_brightest,
                     interpolate_to_uniform=interpolate_to_uniform,
                 )


### PR DESCRIPTION
The previous inversion API called the errors in a mesh source reconstruction as the property `errors`, which were defined as the variance in each mesh pixel.

This was confusing, as the `errors` were defined differently from the `noise_map` used throughout the code in dataset objects, and the errors required a `np.sqrt` to become the RMS standard deviation values like the `noise_map`.

This PR renames the inversion `errors` to the `reconstruction_noise_map` and includes the `np.sqrt` such that they are RMS standard deviations consistent with dataset objects.