### PR TITLE
feature/positions_lh_mass_centre

### DIFF
--- a/test_autolens/analysis/test_result.py
+++ b/test_autolens/analysis/test_result.py
@@ -291,6 +291,39 @@ def test__positions_likelihood_from(analysis_imaging_7x7):
     assert positions_likelihood.threshold == pytest.approx(0.2, 1.0e-4)
 
 
+def test__positions_likelihood_from__mass_centre_radial_distance_min(
+    analysis_imaging_7x7,
+):
+    tracer = al.Tracer(
+        galaxies=[
+            al.Galaxy(
+                redshift=0.5,
+                mass=al.mp.Isothermal(
+                    centre=(0.1, 0.0), einstein_radius=1.0, ell_comps=(0.0, 0.0)
+                ),
+            ),
+            al.Galaxy(redshift=1.0, bulge=al.lp.SersicSph(centre=(0.0, 0.0))),
+        ]
+    )
+
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=tracer)
+
+    result = res.Result(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
+
+    positions_likelihood = result.positions_likelihood_from(
+        factor=0.1, minimum_threshold=0.2, mass_centre_radial_distance_min=0.1
+    )
+
+    assert isinstance(positions_likelihood, al.PositionsLHPenalty)
+    assert len(positions_likelihood.positions) == 2
+    assert positions_likelihood.positions[0] == pytest.approx(
+        (-1.00097656e00, 5.63818622e-04), 1.0e-4
+    )
+    assert positions_likelihood.positions[1] == pytest.approx(
+        (1.00097656e00, -5.63818622e-04), 1.0e-4
+    )
+
+
 def test__results_include_mask__available_as_property(
     analysis_imaging_7x7, masked_imaging_7x7, samples_summary_with_result
 ):


### PR DESCRIPTION
When creating a positions likelihood penalty,  the mass model central image is removed from the solution, as this is rarely physically observed and therefore should not be included in the likelihood penalty or resampling. It is removed by setting a positive magnification threshold in the `PointSolver`. For strange lens models the central image may still be solved for, in which case the `mass_centre_radial_distance_min` parameter can be used to remove it.