### PR TITLE
Feature/remove convolver

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -9,7 +9,6 @@ from autoarray.dataset.grids import GridsInterface
 from autoarray.dataset.dataset_model import DatasetModel
 from autoarray.mask.mask_1d import Mask1D
 from autoarray.mask.mask_2d import Mask2D
-from autoarray.operators.convolver import Convolver
 from autoarray.operators.over_sampling.over_sampler import OverSampler  # noqa
 from autoarray.inversion.inversion.dataset_interface import DatasetInterface
 from autoarray.inversion.inversion.mapper_valued import MapperValued

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -84,7 +84,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         """
         return self.tracer.blurred_image_2d_from(
             grid=self.grids.lp,
-            convolver=self.dataset.convolver,
+            psf=self.dataset.psf,
             blurring_grid=self.grids.blurring,
         )
 
@@ -103,7 +103,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             data=self.profile_subtracted_image,
             noise_map=self.noise_map,
             grids=self.grids,
-            convolver=self.dataset.convolver,
+            psf=self.dataset.psf,
             w_tilde=self.w_tilde,
         )
 
@@ -163,7 +163,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
 
         galaxy_blurred_image_2d_dict = self.tracer.galaxy_blurred_image_2d_dict_from(
             grid=self.grids.lp,
-            convolver=self.dataset.convolver,
+            psf=self.dataset.psf,
             blurring_grid=self.grids.blurring,
         )
 

--- a/autolens/lens/to_inversion.py
+++ b/autolens/lens/to_inversion.py
@@ -180,7 +180,7 @@ class TracerToInversion(ag.AbstractToInversion):
                 data=self.dataset.data,
                 noise_map=self.dataset.noise_map,
                 grids=grids,
-                convolver=self.convolver,
+                psf=self.psf,
                 transformer=self.transformer,
                 w_tilde=self.dataset.w_tilde,
             )

--- a/autolens/lens/tracer.py
+++ b/autolens/lens/tracer.py
@@ -1106,5 +1106,5 @@ class Tracer(ABC, ag.OperateImageGalaxies, ag.OperateDeflections):
                         )
 
     @aa.profile_func
-    def convolve_via_convolver(self, image, blurring_image, convolver):
-        return convolver.convolve_image(image=image, blurring_image=blurring_image)
+    def convolve_via_psf(self, image, blurring_image, psf):
+        return psf.convolve_image(image=image, blurring_image=blurring_image)

--- a/test_autolens/conftest.py
+++ b/test_autolens/conftest.py
@@ -119,9 +119,9 @@ def make_psf_3x3():
     return fixtures.make_psf_3x3()
 
 
-@pytest.fixture(name="convolver_7x7")
-def make_convolver_7x7():
-    return fixtures.make_convolver_7x7()
+@pytest.fixture(name="psf_3x3")
+def make_psf_3x3():
+    return fixtures.make_psf_3x3()
 
 
 @pytest.fixture(name="imaging_7x7")

--- a/test_autolens/imaging/test_fit_imaging.py
+++ b/test_autolens/imaging/test_fit_imaging.py
@@ -480,7 +480,7 @@ def test__galaxy_model_image_dict(masked_imaging_7x7):
 
     blurred_image_2d_list = tracer.blurred_image_2d_list_from(
         grid=masked_imaging_7x7.grids.lp,
-        convolver=masked_imaging_7x7.convolver,
+        psf=masked_imaging_7x7.psf,
         blurring_grid=masked_imaging_7x7.grids.blurring,
     )
 
@@ -596,19 +596,19 @@ def test__subtracted_image_of_galaxies_dict(masked_imaging_7x7):
     g0_image = g0.blurred_image_2d_from(
         grid=masked_imaging_7x7.grids.lp,
         blurring_grid=masked_imaging_7x7.grids.blurring,
-        convolver=masked_imaging_7x7.convolver
+        psf=masked_imaging_7x7.psf
     )
 
     g1_image = g1.blurred_image_2d_from(
         grid=masked_imaging_7x7.grids.lp,
         blurring_grid=masked_imaging_7x7.grids.blurring,
-        convolver=masked_imaging_7x7.convolver
+        psf=masked_imaging_7x7.psf
     )
 
     g2_image = g2.blurred_image_2d_from(
         grid=masked_imaging_7x7.grids.lp,
         blurring_grid=masked_imaging_7x7.grids.blurring,
-        convolver=masked_imaging_7x7.convolver
+        psf=masked_imaging_7x7.psf
     )
 
     assert fit.subtracted_images_of_galaxies_dict[g0] == pytest.approx(
@@ -637,7 +637,7 @@ def test__subtracted_image_of_galaxies_dict(masked_imaging_7x7):
 
     blurred_image_2d_list = tracer.blurred_image_2d_list_from(
         grid=masked_imaging_7x7.grids.lp,
-        convolver=masked_imaging_7x7.convolver,
+        psf=masked_imaging_7x7.psf,
         blurring_grid=masked_imaging_7x7.grids.blurring,
     )
 
@@ -741,7 +741,7 @@ def test___unmasked_blurred_images(masked_imaging_7x7):
 
     blurred_images_of_planes = tracer.blurred_image_2d_list_from(
         grid=masked_imaging_7x7.grids.lp,
-        convolver=masked_imaging_7x7.convolver,
+        psf=masked_imaging_7x7.psf,
         blurring_grid=masked_imaging_7x7.grids.blurring,
     )
 

--- a/test_autolens/imaging/test_simulate_and_fit_imaging.py
+++ b/test_autolens/imaging/test_simulate_and_fit_imaging.py
@@ -199,7 +199,7 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_agree_with_standa
 
     lens_galaxy_image = lens_galaxy.blurred_image_2d_from(
         grid=masked_dataset.grids.lp,
-        convolver=masked_dataset.convolver,
+        psf=masked_dataset.psf,
         blurring_grid=masked_dataset.grids.blurring,
     )
 
@@ -217,7 +217,7 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_agree_with_standa
 
     source_galaxy_image = source_galaxy.blurred_image_2d_from(
         grid=traced_grid_2d_list[1],
-        convolver=masked_dataset.convolver,
+        psf=masked_dataset.psf,
         blurring_grid=traced_blurring_grid_2d_list[1],
     )
 
@@ -316,7 +316,7 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_and_pixelization(
 
     lens_galaxy_image = lens_galaxy.blurred_image_2d_from(
         grid=masked_dataset.grids.lp,
-        convolver=masked_dataset.convolver,
+        psf=masked_dataset.psf,
         blurring_grid=masked_dataset.grids.blurring,
     )
 
@@ -464,7 +464,7 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_and_pixelization_
 
     lens_galaxy_image = lens_galaxy.blurred_image_2d_from(
         grid=masked_dataset.grids.lp,
-        convolver=masked_dataset.convolver,
+        psf=masked_dataset.psf,
         blurring_grid=masked_dataset.grids.blurring,
     )
 

--- a/test_autolens/lens/test_operate.py
+++ b/test_autolens/lens/test_operate.py
@@ -48,6 +48,7 @@ def test__operate_image__blurred_images_2d_via_psf_from__for_tracer_gives_list_o
     assert (blurred_image_list[0].native == blurred_image_0.native).all()
     assert (blurred_image_list[1].native == blurred_image_1.native).all()
 
+
 def test__operate_image__visibilities_of_planes_from_grid_and_transformer(
     grid_2d_7x7, transformer_7x7_7
 ):

--- a/test_autolens/lens/test_operate.py
+++ b/test_autolens/lens/test_operate.py
@@ -48,57 +48,6 @@ def test__operate_image__blurred_images_2d_via_psf_from__for_tracer_gives_list_o
     assert (blurred_image_list[0].native == blurred_image_0.native).all()
     assert (blurred_image_list[1].native == blurred_image_1.native).all()
 
-
-def test__operate_image__blurred_images_2d_via_convolver_from__for_tracer_gives_list_of_planes(
-    grid_2d_7x7, blurring_grid_2d_7x7, convolver_7x7
-):
-    g0 = al.Galaxy(
-        redshift=0.5,
-        light_profile=al.lp.Sersic(intensity=1.0),
-        mass_profile=al.mp.IsothermalSph(einstein_radius=1.0),
-    )
-    g1 = al.Galaxy(redshift=1.0, light_profile=al.lp.Sersic(intensity=2.0))
-
-    blurred_image_0 = g0.blurred_image_2d_from(
-        grid=grid_2d_7x7,
-        convolver=convolver_7x7,
-        blurring_grid=blurring_grid_2d_7x7,
-    )
-
-    source_grid_2d_7x7 = g0.traced_grid_2d_from(grid=grid_2d_7x7)
-    source_blurring_grid_2d_7x7 = g0.traced_grid_2d_from(grid=blurring_grid_2d_7x7)
-
-    blurred_image_1 = g1.blurred_image_2d_from(
-        grid=source_grid_2d_7x7,
-        convolver=convolver_7x7,
-        blurring_grid=source_blurring_grid_2d_7x7,
-    )
-
-    tracer = al.Tracer(galaxies=[g0, g1], cosmology=al.cosmo.Planck15())
-
-    blurred_image = tracer.blurred_image_2d_from(
-        grid=grid_2d_7x7,
-        convolver=convolver_7x7,
-        blurring_grid=blurring_grid_2d_7x7,
-    )
-
-    assert blurred_image.native == pytest.approx(
-        blurred_image_0.native + blurred_image_1.native, 1.0e-4
-    )
-
-    blurred_image_list = tracer.blurred_image_2d_list_from(
-        grid=grid_2d_7x7,
-        convolver=convolver_7x7,
-        blurring_grid=blurring_grid_2d_7x7,
-    )
-
-    assert (blurred_image_list[0].slim == blurred_image_0.slim).all()
-    assert (blurred_image_list[1].slim == blurred_image_1.slim).all()
-
-    assert (blurred_image_list[0].native == blurred_image_0.native).all()
-    assert (blurred_image_list[1].native == blurred_image_1.native).all()
-
-
 def test__operate_image__visibilities_of_planes_from_grid_and_transformer(
     grid_2d_7x7, transformer_7x7_7
 ):
@@ -124,7 +73,7 @@ def test__operate_image__visibilities_of_planes_from_grid_and_transformer(
 
 
 def test__operate_image__galaxy_blurred_image_2d_dict_from(
-    grid_2d_7x7, blurring_grid_2d_7x7, convolver_7x7
+    grid_2d_7x7, blurring_grid_2d_7x7, psf_3x3
 ):
     g0 = al.Galaxy(redshift=0.5, light_profile=al.lp.Sersic(intensity=1.0))
     g1 = al.Galaxy(
@@ -139,19 +88,19 @@ def test__operate_image__galaxy_blurred_image_2d_dict_from(
 
     g0_blurred_image = g0.blurred_image_2d_from(
         grid=grid_2d_7x7,
-        convolver=convolver_7x7,
+        psf=psf_3x3,
         blurring_grid=blurring_grid_2d_7x7,
     )
 
     g1_blurred_image = g1.blurred_image_2d_from(
         grid=grid_2d_7x7,
-        convolver=convolver_7x7,
+        psf=psf_3x3,
         blurring_grid=blurring_grid_2d_7x7,
     )
 
     g2_blurred_image = g2.blurred_image_2d_from(
         grid=grid_2d_7x7,
-        convolver=convolver_7x7,
+        psf=psf_3x3,
         blurring_grid=blurring_grid_2d_7x7,
     )
 
@@ -160,7 +109,7 @@ def test__operate_image__galaxy_blurred_image_2d_dict_from(
 
     g3_blurred_image = g3.blurred_image_2d_from(
         grid=source_grid_2d_7x7,
-        convolver=convolver_7x7,
+        psf=psf_3x3,
         blurring_grid=source_blurring_grid_2d_7x7,
     )
 
@@ -168,7 +117,7 @@ def test__operate_image__galaxy_blurred_image_2d_dict_from(
 
     blurred_image_dict = tracer.galaxy_blurred_image_2d_dict_from(
         grid=grid_2d_7x7,
-        convolver=convolver_7x7,
+        psf=psf_3x3,
         blurring_grid=blurring_grid_2d_7x7,
     )
 

--- a/test_autolens/lens/test_to_inversion.py
+++ b/test_autolens/lens/test_to_inversion.py
@@ -463,7 +463,7 @@ def test__inversion_imaging_from(grid_2d_7x7, masked_imaging_7x7):
         data=masked_imaging_7x7.data,
         noise_map=masked_imaging_7x7.noise_map,
         grids=grids,
-        convolver=masked_imaging_7x7.convolver,
+        psf=masked_imaging_7x7.psf,
     )
 
     g_linear = al.Galaxy(redshift=0.5, light_linear=al.lp_linear.Sersic())


### PR DESCRIPTION
The `Convolver` object mapped out the 2D convolution calculation for a 2D mask and 2D kernel, using the fact that for model-fitting both quantities were fixed and therefore the exact sequence of calculations required could be precomputed in memory.

This object relies heavily on in-place memory manipulation and therefore is not suitable for JAX, therefore I have removed it.

All 2D convolutions are now performed using standard `jax.scipy` convolution methods on 2D arrays.

The `Conolver` object worked on the contents of masked arrays mapped to 1D representation, and the current JAX implementation of convolutions requires mapping back and forth from 1D and 2D. This likely leads to a loss of performance and we may need to optimize these functions in the future.