### PR TITLE
Feature/fits reconstruction

### DIFF
--- a/autolens/aggregator/subplot.py
+++ b/autolens/aggregator/subplot.py
@@ -17,7 +17,7 @@ class FITSFit(Enum):
     The HDUs that can be extracted from the fit.fits file.
     """
 
-    model_image = "MODEL_IMAGE"
+    model_data = "MODEL_DATA"
     residual_map = "RESIDUAL_MAP"
     normalized_residual_map = "NORMALIZED_RESIDUAL_MAP"
     chi_squared_map = "CHI_SQUARED_MAP"
@@ -68,7 +68,7 @@ class SubplotFit(Enum):
     data = (0, 0)
     data_source_scale = (1, 0)
     signal_to_noise_map = (2, 0)
-    model_image = (3, 0)
+    model_data = (3, 0)
     lens_light_model = (1, 0)
     lens_light_subtracted_image = (1, 1)
     source_model_image = (1, 2)
@@ -89,7 +89,7 @@ class SubplotFitLog10(Enum):
     data = (0, 0)
     data_source_scale = (1, 0)
     signal_to_noise_map = (2, 0)
-    model_image = (3, 0)
+    model_data = (3, 0)
     lens_light_model = (1, 0)
     lens_light_subtracted_image = (1, 1)
     source_model_image = (1, 2)

--- a/autolens/config/visualize/plots.yaml
+++ b/autolens/config/visualize/plots.yaml
@@ -37,7 +37,7 @@ tracer:                                    # Settings for plots of tracers (e.g.
 inversion:                                 # Settings for plots of inversions (e.g. InversionPlotter).
   subplot_inversion: true                  # Plot subplot of all quantities in each inversion (e.g. reconstrucuted image, reconstruction)?
   subplot_mappings: true                   # Plot subplot of the image-to-source pixels mappings of each pixelization?
-  fits_reconstruction: false               # output reconstruction.fits containing the reconstructed pixelization and noise map on the adaptive mesh?
+  fits_reconstruction: false          # output reconstruction_mesh.fits containing the reconstructed pixelization and noise map on the source-plane mesh?
 
 adapt:                                     # Settings for plots of adapt images used by adaptive pixelizations.
   subplot_adapt_images: true               # Plot subplot showing each adapt image used for adaptive pixelization?

--- a/autolens/config/visualize/plots.yaml
+++ b/autolens/config/visualize/plots.yaml
@@ -37,7 +37,7 @@ tracer:                                    # Settings for plots of tracers (e.g.
 inversion:                                 # Settings for plots of inversions (e.g. InversionPlotter).
   subplot_inversion: true                  # Plot subplot of all quantities in each inversion (e.g. reconstrucuted image, reconstruction)?
   subplot_mappings: true                   # Plot subplot of the image-to-source pixels mappings of each pixelization?
-  fits_reconstruction: false          # output reconstruction_mesh.fits containing the reconstructed pixelization and noise map on the source-plane mesh?
+  csv_reconstruction: false                # output reconstruction.csv containing the source-plane mesh y, x, reconstruction and noise map values.
 
 adapt:                                     # Settings for plots of adapt images used by adaptive pixelizations.
   subplot_adapt_images: true               # Plot subplot showing each adapt image used for adaptive pixelization?

--- a/autolens/config/visualize/plots.yaml
+++ b/autolens/config/visualize/plots.yaml
@@ -11,6 +11,7 @@
 # These can be disabled to save on hard-disk space but will lead to certain database functionality being disabled.
 
 subplot_format: [png]                      # Output format of all subplots, can be png, pdf or both (e.g. [png, pdf])
+fits_are_zoomed: true                      # If true, output .fits files are zoomed in on the center of the unmasked region image, saving hard-disk space.
 
 dataset:                                   # Settings for plots of all datasets (e.g. ImagingPlotter, InterferometerPlotter).
   subplot_dataset: true                    # Plot subplot containing all dataset quantities (e.g. the data, noise-map, etc.)?


### PR DESCRIPTION
In the results `image` folder there is now a .csv file called `inversion_reconstruction_0.csv` which contains the
y and x coordinates of the pixelization mesh, the reconstruct values and the noise map of these values.

This file is provides all information on the source reconstruciton in a format that does not depend autolens
and therefore be easily loaded to create images of the source or shared collaobrations who do not have PyAutoLens
installed.
