### PR TITLE
Feature/zoom array

### DIFF
--- a/autolens/aggregator/subplot.py
+++ b/autolens/aggregator/subplot.py
@@ -17,7 +17,7 @@ class FITSFit(Enum):
     The HDUs that can be extracted from the fit.fits file.
     """
 
-    model_image = "MODEL_IMAGE"
+    model_data = "MODEL_DATA"
     residual_map = "RESIDUAL_MAP"
     normalized_residual_map = "NORMALIZED_RESIDUAL_MAP"
     chi_squared_map = "CHI_SQUARED_MAP"
@@ -68,7 +68,7 @@ class SubplotFit(Enum):
     data = (0, 0)
     data_source_scale = (1, 0)
     signal_to_noise_map = (2, 0)
-    model_image = (3, 0)
+    model_data = (3, 0)
     lens_light_model = (1, 0)
     lens_light_subtracted_image = (1, 1)
     source_model_image = (1, 2)
@@ -89,7 +89,7 @@ class SubplotFitLog10(Enum):
     data = (0, 0)
     data_source_scale = (1, 0)
     signal_to_noise_map = (2, 0)
-    model_image = (3, 0)
+    model_data = (3, 0)
     lens_light_model = (1, 0)
     lens_light_subtracted_image = (1, 1)
     source_model_image = (1, 2)

--- a/autolens/analysis/plotter_interface.py
+++ b/autolens/analysis/plotter_interface.py
@@ -65,14 +65,20 @@ class PlotterInterface(AgPlotterInterface):
             tracer_plotter.subplot_galaxies_images()
 
         if should_plot("fits_tracer"):
+
+            zoom = aa.Zoom2D(mask=grid.mask)
+            mask = zoom.mask_2d_from(buffer=1)
+            grid_zoom = aa.Grid2D.from_mask(mask=mask)
+
+            image_list = [
+                tracer.convergence_2d_from(grid=grid_zoom).native,
+                tracer.potential_2d_from(grid=grid_zoom).native,
+                tracer.deflections_yx_2d_from(grid=grid_zoom).native[:, :, 0],
+                tracer.deflections_yx_2d_from(grid=grid_zoom).native[:, :, 1],
+            ]
+
             hdu_list = hdu_list_for_output_from(
-                values_list=[
-                    grid.mask.astype("float"),
-                    tracer.convergence_2d_from(grid=grid).native,
-                    tracer.potential_2d_from(grid=grid).native,
-                    tracer.deflections_yx_2d_from(grid=grid).native[:, :, 0],
-                    tracer.deflections_yx_2d_from(grid=grid).native[:, :, 1],
-                ],
+                values_list=[image_list[0].mask.astype("float")] + image_list,
                 ext_name_list=[
                     "mask",
                     "convergence",

--- a/autolens/config/visualize/plots.yaml
+++ b/autolens/config/visualize/plots.yaml
@@ -37,7 +37,7 @@ tracer:                                    # Settings for plots of tracers (e.g.
 inversion:                                 # Settings for plots of inversions (e.g. InversionPlotter).
   subplot_inversion: true                  # Plot subplot of all quantities in each inversion (e.g. reconstrucuted image, reconstruction)?
   subplot_mappings: true                   # Plot subplot of the image-to-source pixels mappings of each pixelization?
-  fits_reconstruction: false               # output reconstruction.fits containing the reconstructed pixelization and noise map on the adaptive mesh?
+  fits_reconstruction: false          # output reconstruction_mesh.fits containing the reconstructed pixelization and noise map on the source-plane mesh?
 
 adapt:                                     # Settings for plots of adapt images used by adaptive pixelizations.
   subplot_adapt_images: true               # Plot subplot showing each adapt image used for adaptive pixelization?

--- a/autolens/config/visualize/plots.yaml
+++ b/autolens/config/visualize/plots.yaml
@@ -37,7 +37,7 @@ tracer:                                    # Settings for plots of tracers (e.g.
 inversion:                                 # Settings for plots of inversions (e.g. InversionPlotter).
   subplot_inversion: true                  # Plot subplot of all quantities in each inversion (e.g. reconstrucuted image, reconstruction)?
   subplot_mappings: true                   # Plot subplot of the image-to-source pixels mappings of each pixelization?
-  fits_reconstruction: false          # output reconstruction_mesh.fits containing the reconstructed pixelization and noise map on the source-plane mesh?
+  csv_reconstruction: false                # output reconstruction.csv containing the source-plane mesh y, x, reconstruction and noise map values.
 
 adapt:                                     # Settings for plots of adapt images used by adaptive pixelizations.
   subplot_adapt_images: true               # Plot subplot showing each adapt image used for adaptive pixelization?

--- a/autolens/config/visualize/plots.yaml
+++ b/autolens/config/visualize/plots.yaml
@@ -11,6 +11,7 @@
 # These can be disabled to save on hard-disk space but will lead to certain database functionality being disabled.
 
 subplot_format: [png]                      # Output format of all subplots, can be png, pdf or both (e.g. [png, pdf])
+fits_are_zoomed: true                      # If true, output .fits files are zoomed in on the center of the unmasked region image, saving hard-disk space.
 
 dataset:                                   # Settings for plots of all datasets (e.g. ImagingPlotter, InterferometerPlotter).
   subplot_dataset: true                    # Plot subplot containing all dataset quantities (e.g. the data, noise-map, etc.)?

--- a/autolens/imaging/model/visualizer.py
+++ b/autolens/imaging/model/visualizer.py
@@ -102,8 +102,10 @@ class VisualizerImaging(af.Visualizer):
 
         tracer = fit.tracer_linear_light_profiles_to_light_profiles
 
-        extent = fit.data.extent_of_zoomed_array(buffer=0)
-        shape_native = fit.data.zoomed_around_mask(buffer=0).shape_native
+        zoom = ag.Zoom2D(mask=fit.mask)
+
+        extent = zoom.extent_from(buffer=0)
+        shape_native = zoom.shape_native
 
         grid = ag.Grid2D.from_extent(extent=extent, shape_native=shape_native)
 

--- a/autolens/imaging/plot/fit_imaging_plotters.py
+++ b/autolens/imaging/plot/fit_imaging_plotters.py
@@ -80,12 +80,11 @@ class FitImagingPlotter(Plotter):
         Returns an `TracerPlotter` corresponding to the `Tracer` in the `FitImaging`.
         """
 
-        extent = self.fit.data.extent_of_zoomed_array(buffer=0)
-        shape_native = self.fit.data.zoomed_around_mask(buffer=0).shape_native
+        zoom = aa.Zoom2D(mask=self.fit.mask)
 
         grid = aa.Grid2D.from_extent(
-            extent=extent,
-            shape_native=shape_native
+            extent=zoom.extent_from(buffer=0),
+            shape_native=zoom.shape_native
         )
 
         return TracerPlotter(

--- a/test_autolens/analysis/test_plotter_interface.py
+++ b/test_autolens/analysis/test_plotter_interface.py
@@ -33,7 +33,7 @@ def test__tracer(
         file_path=path.join(plot_path, "tracer.fits"), hdu=0
     )
 
-    assert image.shape == (7, 7)
+    assert image.shape == (5, 5)
 
 
 def test__image_with_positions(

--- a/test_autolens/imaging/model/test_plotter_interface_imaging.py
+++ b/test_autolens/imaging/model/test_plotter_interface_imaging.py
@@ -34,13 +34,13 @@ def test__fit_imaging(
         file_path=path.join(plot_path, "fit.fits"), hdu=0
     )
 
-    assert image.shape == (7, 7)
+    assert image.shape == (5, 5)
 
     image = al.ndarray_via_fits_from(
         file_path=path.join(plot_path, "model_galaxy_images.fits"), hdu=0
     )
 
-    assert image.shape == (7, 7)
+    assert image.shape == (5, 5)
 
 def test__fit_imaging_combined(
     fit_imaging_x2_plane_inversion_7x7, plot_path, plot_patch

--- a/test_autolens/interferometer/model/test_plotter_interface_interferometer.py
+++ b/test_autolens/interferometer/model/test_plotter_interface_interferometer.py
@@ -36,7 +36,7 @@ def test__fit_interferometer(
         file_path=path.join(plot_path, "model_galaxy_images.fits"), hdu=0
     )
 
-    assert image.shape == (7, 7)
+    assert image.shape == (5, 5)
 
     image = al.ndarray_via_fits_from(
         file_path=path.join(plot_path, "dirty_images.fits"), hdu=0


### PR DESCRIPTION
Original goal of PR was to make it so .fits file outputs are zoomed in around the mask based on config, saving file disk space use.

This ended up with a large refactor moving all zoom functionality to a standalone class.

In PyAutoGalaxy and PyAutoLens this led to refactoring of .fits outputs to zoom in before output to .fits.