### PR TITLE
refactor: use PYAUTO_SKIP_CHECKS and PYAUTO_SKIP_VISUALIZATION

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,10 +38,10 @@ black autolens/
 
 ### Plot Output Mode
 
-Set `PYAUTOARRAY_OUTPUT_MODE=1` to capture every figure produced by a script into numbered PNG files in `./output_mode/<script_name>/`. This is useful for visually inspecting all plots from an integration test without needing a display.
+Set `PYAUTO_OUTPUT_MODE=1` to capture every figure produced by a script into numbered PNG files in `./output_mode/<script_name>/`. This is useful for visually inspecting all plots from an integration test without needing a display.
 
 ```bash
-PYAUTOARRAY_OUTPUT_MODE=1 python scripts/my_script.py
+PYAUTO_OUTPUT_MODE=1 python scripts/my_script.py
 # -> ./output_mode/my_script/0_fit.png, 1_tracer.png, ...
 ```
 

--- a/autolens/analysis/analysis/dataset.py
+++ b/autolens/analysis/analysis/dataset.py
@@ -31,7 +31,7 @@ from autolens.analysis.result import ResultDataset
 from autolens.analysis.positions import PositionsLH
 
 from autolens import exc
-from autoconf.test_mode import is_test_mode
+from autoconf.test_mode import skip_checks
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +110,7 @@ class AnalysisDataset(AgAnalysisDataset, AnalysisLens):
             raise_inversion_positions_likelihood_exception
         )
 
-        if is_test_mode():
+        if skip_checks():
             self.raise_inversion_positions_likelihood_exception = False
 
     def modify_before_fit(self, paths: af.DirectoryPaths, model: af.Collection):

--- a/autolens/analysis/result.py
+++ b/autolens/analysis/result.py
@@ -31,7 +31,7 @@ from autolens.point.max_separation import (
 )
 from autolens.lens.tracer import Tracer
 from autolens.point.solver import PointSolver
-from autoconf.test_mode import is_test_mode
+from autoconf.test_mode import skip_checks
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +304,7 @@ class Result(AgResultDataset):
         The `PositionsLH` object used to apply a likelihood penalty or resample the positions.
         """
 
-        if is_test_mode():
+        if skip_checks():
             return
 
         positions = (

--- a/autolens/quantity/model/visualizer.py
+++ b/autolens/quantity/model/visualizer.py
@@ -1,7 +1,7 @@
 import os
 
 import autofit as af
-from autoconf.test_mode import is_test_mode
+from autoconf.test_mode import skip_visualization
 
 from autogalaxy.quantity.model.plotter import PlotterQuantity
 
@@ -40,7 +40,7 @@ class VisualizerQuantity(af.Visualizer):
             via a non-linear search).
         """
 
-        if is_test_mode():
+        if skip_visualization():
             return
 
         fit = analysis.fit_quantity_for_instance(instance=instance)


### PR DESCRIPTION
## Summary
Switch position resampling and inversion position checks from `is_test_mode()` to `skip_checks()`, and quantity visualizer from `is_test_mode()` to `skip_visualization()`.

Depends on: rhayes777/PyAutoConf#86, Jammy2211/PyAutoGalaxy#343

## API Changes
No env var renames — behaviour changes only. Position resampling and inversion checks now controlled by `PYAUTO_SKIP_CHECKS`. Quantity visualization controlled by `PYAUTO_SKIP_VISUALIZATION`. See full details below.

## Test Plan
- [x] All 245 PyAutoLens tests pass
- [x] CLAUDE.md documentation updated

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `resample_positions_pdf_from()` now checks `skip_checks()` instead of `is_test_mode()`
- `AnalysisDataset.__init__` inversion position exception now checks `skip_checks()` instead of `is_test_mode()`
- `VisualizerQuantity.visualize()` now checks `skip_visualization()` instead of `is_test_mode()`

### Migration
- Before: `export PYAUTOFIT_TEST_MODE=1` disabled positions + visualization
- After: `export PYAUTO_SKIP_CHECKS=1` for positions, `export PYAUTO_SKIP_VISUALIZATION=1` for visualization

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)