### PR TITLE
build: add Python 3.13 to CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
   unittest:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.12', '3.13']
     steps:
@@ -70,6 +71,8 @@ jobs:
         pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
         if [ "${{ matrix.python-version }}" = "3.12" ]; then
           pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
+        else
+          pip install numba pynufft
         fi
     - name: Run tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,8 +72,7 @@ jobs:
           pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
           pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
         else
-          pip install --only-binary :all: scipy numpy matplotlib h5py contourpy
-          pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
+          pip install --only-binary scipy,numpy,matplotlib,h5py,contourpy ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
           pip install numba
         fi
     - name: Run tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.12', '3.13']
     steps:
     - name: Checkout PyAutoConf
       uses: actions/checkout@v2
@@ -67,7 +67,10 @@ jobs:
         pip3 install setuptools
         pip3 install wheel
         pip3 install pytest coverage pytest-cov
-        pip install ./PyAutoConf ./PyAutoFit "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
+        pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
+        if [ "${{ matrix.python-version }}" = "3.12" ]; then
+          pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
+        fi
     - name: Run tests
       run: |
         export ROOT_DIR=`pwd`

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
           pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
           pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
         else
-          pip install --only-binary scipy,numpy,matplotlib,h5py,contourpy ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
+          pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
           pip install numba
         fi
     - name: Run tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
         if [ "${{ matrix.python-version }}" = "3.12" ]; then
           pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
         else
-          pip install numba pynufft
+          pip install numba
         fi
     - name: Run tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,10 +68,12 @@ jobs:
         pip3 install setuptools
         pip3 install wheel
         pip3 install pytest coverage pytest-cov
-        pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
         if [ "${{ matrix.python-version }}" = "3.12" ]; then
+          pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
           pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
         else
+          pip install --only-binary :all: scipy numpy matplotlib h5py contourpy
+          pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
           pip install numba
         fi
     - name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
   "Natural Language :: English",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.12"
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13"
 ]
 keywords = ["cli"]
 dependencies = [


### PR DESCRIPTION
## Summary
Add Python 3.13 to the CI matrix and classifiers. Same approach as PyAutoGalaxy — on 3.13, optional extras are skipped and numba is installed directly. Both 3.12 and 3.13 pass.

## API Changes
None — internal changes only.

## Test Plan
- [x] CI passes on Python 3.12
- [x] CI passes on Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)