### PR TITLE
docs: update Python version to 3.12-3.13

### DIFF
--- a/docs/installation/conda.rst
+++ b/docs/installation/conda.rst
@@ -30,11 +30,11 @@ First, update conda:
 
 Next, create a conda environment (we name this ``autolens`` to signify it is for the **PyAutoLens** install):
 
-The command below creates this environment with Python 3.11, the most recent supported version of Python:
+The command below creates this environment with Python 3.12:
 
 .. code-block:: bash
 
-    conda create -n autolens python=3.11
+    conda create -n autolens python=3.12
 
 Activate the conda environment (you will have to do this every time you want to run **PyAutoLens**):
 

--- a/docs/installation/overview.rst
+++ b/docs/installation/overview.rst
@@ -3,7 +3,7 @@
 Overview
 ========
 
-**PyAutoLens** requires Python 3.9 - 3.12 and support the Linux, MacOS and Windows operating systems.
+**PyAutoLens** requires Python 3.12 - 3.13 and supports the Linux, MacOS and Windows operating systems.
 
 **PyAutoLens** can be installed via the Python distribution `Anaconda <https://www.anaconda.com/>`_ or using
 `Pypi <https://pypi.org/>`_ to ``pip install autolens`` into your Python distribution.


### PR DESCRIPTION
## Summary
Update installation docs to reflect Python 3.12-3.13 support (was 3.9-3.12). Also updates conda environment example from python=3.11 to python=3.12.

## API Changes
None — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)