### PR TITLE
fix: pin autogalaxy dependency version and update homepage URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,12 @@ classifiers = [
 ]
 keywords = ["cli"]
 dependencies = [
-    "autogalaxy",
+    "autogalaxy==2026.4.13.3",
     "nautilus-sampler==1.0.5"
 ]
 
 [project.urls]
-Homepage = "https://github.com/Jammy2211/PyAutoLens"
+Homepage = "https://github.com/PyAutoLabs/PyAutoLens"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary
- Pin `autogalaxy` to exact version (`==2026.4.13.3`) so pip cannot resolve to wrong PyPI packages
- Update homepage URL from `Jammy2211/PyAutoLens` to `PyAutoLabs/PyAutoLens`
- The release workflow will auto-update the pinned version via sed

## Test plan
- [ ] `pip install autolens` resolves all dependencies to correct PyAuto packages
- [ ] Release workflow sed pattern matches and updates the pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)