### PR TITLE
fix: suppress CLI noise from third-party warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,7 @@ dev = ["pytest", "black"]
 
 [tool.pytest.ini_options]
 testpaths = ["test_autolens"]
+filterwarnings = [
+    "ignore:cuda_plugin_extension:UserWarning",
+    "ignore::DeprecationWarning:jax",
+]


### PR DESCRIPTION
## Summary
Add pytest warning filters for JAX CUDA plugin and JAX deprecation warnings to suppress noise during test collection and runtime.

## API Changes
None — internal changes only.

## Test Plan
- [x] All 246 unit tests pass
- [x] `pytest --co` produces zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)