### PR TITLE
docs(install): clone workspace at tag matching library version

### DIFF
--- a/docs/installation/conda.rst
+++ b/docs/installation/conda.rst
@@ -97,7 +97,8 @@ the ``autolens_workspace``, reducing the download size):
 .. code-block:: bash
 
    cd /path/on/your/computer/you/want/to/put/the/autolens_workspace
-   git clone https://github.com/Jammy2211/autolens_workspace --depth 1
+   AUTOLENS_VERSION=$(python -c "import autolens; print(autolens.__version__)")
+   git clone https://github.com/Jammy2211/autolens_workspace --branch $AUTOLENS_VERSION --depth 1
    cd autolens_workspace
 
 Run the ``welcome.py`` script to get started!

--- a/docs/installation/pip.rst
+++ b/docs/installation/pip.rst
@@ -79,7 +79,8 @@ the ``autolens_workspace``, reducing the download size):
 .. code-block:: bash
 
    cd /path/on/your/computer/you/want/to/put/the/autolens_workspace
-   git clone https://github.com/Jammy2211/autolens_workspace --depth 1
+   AUTOLENS_VERSION=$(python -c "import autolens; print(autolens.__version__)")
+   git clone https://github.com/Jammy2211/autolens_workspace --branch $AUTOLENS_VERSION --depth 1
    cd autolens_workspace
 
 Run the ``welcome.py`` script to get started!


### PR DESCRIPTION
## Summary

Each PyAuto release tags a paired workspace snapshot. The pip and conda install instructions now clone the workspace via `--branch $AUTOLENS_VERSION` (read from the installed library) so example scripts and notebooks line up with the installed library version. Companion to PyAutoLabs/autolens_workspace#71.

## API Changes

None — documentation only.

See full details below.

## Test Plan

- [ ] Render docs and confirm the new bash snippet renders correctly.
- [ ] Once a release is cut with the new pipeline (PyAutoBuild PR), follow the install docs end-to-end and confirm the cloned workspace's `version.txt` matches the installed `autolens.__version__`.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `docs/installation/pip.rst` and `docs/installation/conda.rst`: workspace clone command now reads the installed library version and clones the matching tag, rather than a bare `--depth 1` clone of the (formerly default) `release` branch.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)