### PR TITLE
feat: JAX pytree registration for FitInterferometer + MGE source

### DIFF
--- a/autolens/interferometer/model/analysis.py
+++ b/autolens/interferometer/model/analysis.py
@@ -173,6 +173,9 @@ class AnalysisInterferometer(AnalysisDataset):
             The fit of the plane to the interferometer dataset, which includes the log likelihood.
         """
 
+        if self._use_jax:
+            self._register_fit_interferometer_pytrees()
+
         tracer = self.tracer_via_instance_from(
             instance=instance,
         )
@@ -186,6 +189,27 @@ class AnalysisInterferometer(AnalysisDataset):
             settings=self.settings,
             xp=self._xp,
         )
+
+    @staticmethod
+    def _register_fit_interferometer_pytrees() -> None:
+        """Register every type reachable from a ``FitInterferometer`` return
+        value so ``jax.jit(fit_from)`` can flatten its output.
+
+        ``dataset``, ``adapt_images`` and ``settings`` are constants per
+        analysis — ride as aux so JAX does not recurse into them. Everything
+        else (``tracer`` and the autoarray wrappers it carries) is dynamic
+        per fit.
+        """
+        from autoarray.abstract_ndarray import register_instance_pytree
+        from autoarray.dataset.dataset_model import DatasetModel  # fit-interferometer-pytree-mge
+        from autolens.lens.tracer import Tracer
+
+        register_instance_pytree(
+            FitInterferometer,
+            no_flatten=("dataset", "adapt_images", "settings"),
+        )
+        register_instance_pytree(Tracer, no_flatten=("cosmology",))
+        register_instance_pytree(DatasetModel)  # fit-interferometer-pytree-mge
 
     def save_attributes(self, paths: af.DirectoryPaths):
         """


### PR DESCRIPTION
## Summary

Extends Path A (``jax.jit``-wrapped ``analysis.fit_from``) to ``FitInterferometer``
with an MGE source. The imaging-side MGE variant was already shipped
(``fit-imaging-pytree`` + ``fit-imaging-pytree-lp`` lines); this lands the equivalent
on the uv-plane side.

## API Changes

Adds ``_register_fit_interferometer_pytrees`` to ``AnalysisInterferometer`` and calls
it at the top of ``fit_from`` when ``use_jax=True``. Registers ``FitInterferometer``,
``Tracer`` and ``DatasetModel`` as pytrees with the appropriate ``no_flatten`` aux
fields. No public signature changes.

See full details below.

## Test Plan

- [x] ``pytest test_autolens/ -q --ignore=test_autolens/aggregator --ignore=test_autolens/config`` — 252 passed
- [x] ``scripts/jax_likelihood_functions/interferometer/mge_pytree.py`` PASSes —
  NumPy = ``-3154.2167393875`` / JIT = ``-3154.2167393875`` (match to rtol~1e-15)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- ``AnalysisInterferometer._register_fit_interferometer_pytrees()`` — new static
  method that calls ``register_instance_pytree`` for ``FitInterferometer``,
  ``Tracer`` and ``DatasetModel``. Called from ``fit_from`` when ``use_jax=True``.

### Changed Behaviour
- ``AnalysisInterferometer.fit_from`` now registers the pytree surface for its
  return value on the JAX path, enabling ``jax.jit(analysis.fit_from)`` to flatten
  the returned ``FitInterferometer``. NumPy path (``use_jax=False``) is unchanged.

### Registrations
- ``FitInterferometer``: ``no_flatten=("dataset", "adapt_images", "settings")``
- ``Tracer``: ``no_flatten=("cosmology",)`` (already registered by imaging site — safe re-registration)
- ``DatasetModel``: ``no_flatten=()`` — all dynamic (``background_sky_level``, ``grid_offset``)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)