### PR TITLE
docs: update HowToLens references after extraction to standalone repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,9 @@ The following links are useful for new starters:
 
 - `The introduction Jupyter Notebook on Google Colab <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb>`_: try **PyAutoLens** in a web browser (without installation).
 
-- `The autolens_workspace GitHub repository <https://github.com/Jammy2211/autolens_workspace>`_: example scripts and the HowToLens Jupyter notebook lectures.
+- `The autolens_workspace GitHub repository <https://github.com/PyAutoLabs/autolens_workspace>`_: example scripts covering every **PyAutoLens** use case.
+
+- `The HowToLens GitHub repository <https://github.com/PyAutoLabs/HowToLens>`_: a Jupyter notebook lecture series teaching strong lensing and lens modeling from the ground up.
 
 Community & Support
 -------------------
@@ -80,7 +82,7 @@ For users less familiar with gravitational lensing, Bayesian inference and scien
 you may wish to read through the **HowToLens** lectures. These teach you the basic principles of gravitational lensing
 and Bayesian inference, with the content pitched at undergraduate level and above.
 
-A complete overview of the lectures `is provided on the HowToLens readthedocs page <https://pyautolens.readthedocs.io/en/latest/howtolens/howtolens.html>`_.
+A complete overview of the lectures `is provided on the HowToLens readthedocs page <https://pyautolens.readthedocs.io/en/latest/howtolens/howtolens.html>`_, and the notebooks themselves live in the `PyAutoLabs/HowToLens <https://github.com/PyAutoLabs/HowToLens>`_ repository.
 
 Citations
 ---------

--- a/docs/general/workspace.rst
+++ b/docs/general/workspace.rst
@@ -57,9 +57,10 @@ See `here <https://pyautolens.readthedocs.io/en/latest/advanced/slam.html>`_ for
 HowToLens
 ---------
 
-The **HowToLens** lecture series are a collection of Jupyter notebooks describing how to build a **PyAutoLens** model
-fitting project and giving illustrations of different statistical methods and techniques.
+The **HowToLens** lecture series is a collection of Jupyter notebooks describing how to build a **PyAutoLens** model
+fitting project and giving illustrations of different statistical methods and techniques. It ships as a standalone
+repository at `PyAutoLabs/HowToLens <https://github.com/PyAutoLabs/HowToLens>`_ (separate from the workspace).
 
 Checkout the
-`tutorials section <file:///Users/Jammy/Code/PyAutoLabs/PyAutoLens/docs/_build/tutorials/howtolens.html>`_ for a
+`tutorials section <https://pyautolens.readthedocs.io/en/latest/howtolens/howtolens.html>`_ for a
 full description of the lectures and online examples of every notebook.

--- a/docs/howtolens/chapter_1_introduction.rst
+++ b/docs/howtolens/chapter_1_introduction.rst
@@ -7,29 +7,29 @@ In chapter 1, we introduce you to strong gravitational lensing and the core **Py
 
 The chapter contains the following tutorials:
 
-`Tutorial 0: Visualization <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_0_visualization.ipynb>`_
+`Tutorial 0: Visualization <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_0_visualization.ipynb>`_
 - Setting up **PyAutoLens**'s visualization library.
 
-`Tutorial 1: Grids And Galaxies <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_1_grids_and_galaxies.ipynb>`_
+`Tutorial 1: Grids And Galaxies <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_1_grids_and_galaxies.ipynb>`_
 - Using grids of (y,x) coordinates with galaxies made up of light profiles.
 
-`Tutorial 2: Ray Tracing <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_2_ray_tracing.ipynb>`_
+`Tutorial 2: Ray Tracing <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_2_ray_tracing.ipynb>`_
 - Using grids, galaxies and mass profiles to perform strong lens ray-tracing.
 
-`Tutorial 3: More Ray Tracing <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_3_more_ray_tracing.ipynb>`_
+`Tutorial 3: More Ray Tracing <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_3_more_ray_tracing.ipynb>`_
 - Advanced strong lens ray-tracing.
 
-`Tutorial 4: Point Sources <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_4_point_sources.ipynb>`_
+`Tutorial 4: Point Sources <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_4_point_sources.ipynb>`_
 - How lensing calculations when the source galaxy is a point-source (e.g. a quasar).
 
-`Tutorial 5: Lensing Formalism <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_5_lensing_formalism.ipynb>`_
+`Tutorial 5: Lensing Formalism <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_5_lensing_formalism.ipynb>`_
 - The algebraic lensing formalism used to describe strong lensing.
 
-`Tutorial 6: Data <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_6_data.ipynb>`_
+`Tutorial 6: Data <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_6_data.ipynb>`_
 - Loading and inspecting telescope imaging data of a strong lens.
 
-`Tutorial 7: Fitting <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_7_fitting.ipynb>`_
+`Tutorial 7: Fitting <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_7_fitting.ipynb>`_
 - Fitting data with a strong lens model.
 
-`Tutorial 8: Summary <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_8_summary.ipynb>`_
+`Tutorial 8: Summary <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_8_summary.ipynb>`_
 - A summary of the chapter.

--- a/docs/howtolens/chapter_2_lens_modeling.rst
+++ b/docs/howtolens/chapter_2_lens_modeling.rst
@@ -5,26 +5,26 @@ In chapter 2, we'll take you through how to model strong lenses using a non-line
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Non-linear Search <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_1_non_linear_search.ipynb>`_
+`Tutorial 1: Non-linear Search <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_2_lens_modeling/tutorial_1_non_linear_search.ipynb>`_
 - How a non-linear search is used to fit a lens model and the concepts of a parameter space and priors.
 
-`Tutorial 2: Practicalities <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_2_practicalities.ipynb>`_
+`Tutorial 2: Practicalities <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_2_lens_modeling/tutorial_2_practicalities.ipynb>`_
 - Practicalities of performing model-fitting, like how to inspect the results on your hard-disk.
 
-`Tutorial 3: Realism and Complexity <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_3_realism_and_complexity.ipynb>`_
+`Tutorial 3: Realism and Complexity <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_2_lens_modeling/tutorial_3_realism_and_complexity.ipynb>`_
 - Finding a balance between realism and complexity when composing and fitting a lens model.
 
-`Tutorial 4: Dealing with Failure <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_4_dealing_with_failure.ipynb>`_
+`Tutorial 4: Dealing with Failure <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_2_lens_modeling/tutorial_4_dealing_with_failure.ipynb>`_
 - What to do when PyAutoLens finds an inaccurate lens model.
 
-`Tutorial 5: Linear Profiles <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_5_linear_profiles.ipynb>`_
+`Tutorial 5: Linear Profiles <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_2_lens_modeling/tutorial_5_linear_profiles.ipynb>`_
 - Light profiles which capture complex morphologies in a reduced number of non-linear parameters.
 
-`Tutorial 6: Masking and Positions <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_6_masking_and_positions.ipynb>`_
+`Tutorial 6: Masking and Positions <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_2_lens_modeling/tutorial_6_masking_and_positions.ipynb>`_
 - How to mask and mark positions on your data to improve the lens model.
 
-`Tutorial 7: Results <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_7_results.ipynb>`_
+`Tutorial 7: Results <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_2_lens_modeling/tutorial_7_results.ipynb>`_
 - Overview of the results available after successfully fitting a lens model.
 
-`Tutorial 8: Need for Speed <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_8_need_for_speed.ipynb>`_
+`Tutorial 8: Need for Speed <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_2_lens_modeling/tutorial_8_need_for_speed.ipynb>`_
 - How to fit complex models whilst balancing efficiency and run-time.

--- a/docs/howtolens/chapter_3_search_chaining.rst
+++ b/docs/howtolens/chapter_3_search_chaining.rst
@@ -6,20 +6,20 @@ robust modeling of large strong lens samples.
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Search Chaining <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_1_search_chaining.ipynb>`_
+`Tutorial 1: Search Chaining <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_3_search_chaining/tutorial_1_search_chaining.ipynb>`_
 - Breaking the lens modeling procedure into a chained sequence of model-fits.
 
-`Tutorial 2: Prior Passing <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_2_prior_passing.ipynb>`_
+`Tutorial 2: Prior Passing <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_3_search_chaining/tutorial_2_prior_passing.ipynb>`_
 - How the results of earlier searches are passed to later searches.
 
-`Tutorial 3: Lens and Source <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_3_lens_and_source.ipynb>`_
+`Tutorial 3: Lens and Source <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_3_search_chaining/tutorial_3_lens_and_source.ipynb>`_
 - Fitting the lens's light followed by its mass using chained searches.
 
-`Tutorial 4: Two Lens galaxies <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_4_x2_lens_galaxies.ipynb>`_
+`Tutorial 4: Two Lens galaxies <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_3_search_chaining/tutorial_4_x2_lens_galaxies.ipynb>`_
 - Modeling a strong lens with two lens galaxies using chained searches.
 
-`Tutorial 5: Complex Source <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_4_complex_source.ipynb>`_
+`Tutorial 5: Complex Source <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_3_search_chaining/tutorial_4_complex_source.ipynb>`_
 - Using multiple light profiles to fit a complex and irregular source using chained searches.
 
-`Tutorial 6: SLaM <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_6_slam.ipynb>`_
+`Tutorial 6: SLaM <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_3_search_chaining/tutorial_6_slam.ipynb>`_
 - Template pipelines for fitting lens model is standardized ways.

--- a/docs/howtolens/chapter_4_pixelizations.rst
+++ b/docs/howtolens/chapter_4_pixelizations.rst
@@ -5,35 +5,35 @@ In chapter 4, we use **Pixelizations** to reconstruct complex source galaxies on
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Pixelizations <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_1_pixelizations.ipynb>`_
+`Tutorial 1: Pixelizations <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_1_pixelizations.ipynb>`_
 - Creating a pixel-grid in the source-plane.
 
-`Tutorial 2: Mappers <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_2_mappers.ipynb>`_
+`Tutorial 2: Mappers <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_2_mappers.ipynb>`_
 - How a pixelization maps source-pixels to image-pixels.
 
-`Tutorial 3: Inversions <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_3_inversions.ipynb>`_
+`Tutorial 3: Inversions <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_3_inversions.ipynb>`_
 - Inverting the mappings to reconstruct the source's light.
 
-`Tutorial 4: Bayesian Regularization <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_4_bayesian_regularization.ipynb>`_
+`Tutorial 4: Bayesian Regularization <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_4_bayesian_regularization.ipynb>`_
 - Smoothing the source within a Bayesian framework.
 
-`Tutorial 5: Borders <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_5_borders.ipynb>`_
+`Tutorial 5: Borders <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_5_borders.ipynb>`_
 - Preventing highly demagnified image-pixels ruining the inversion.
 
-`Tutorial 6: Lens Modeling  <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_6_lens_modeling.ipynb>`_
+`Tutorial 6: Lens Modeling  <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_6_lens_modeling.ipynb>`_
 - How to use inversions to fit a lens model.
 
-`Tutorial 7: Adaptive Pixelization <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_7_adaptive_pixelization.ipynb>`_
+`Tutorial 7: Adaptive Pixelization <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_7_adaptive_pixelization.ipynb>`_
 - A Voronoi mesh which adapts to the mass model's magnification.
 
-`Tutorial 8: Model Fit <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_8_model_fit.ipynb>`_
+`Tutorial 8: Model Fit <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_8_model_fit.ipynb>`_
 - An example lens modeling pipeline which uses an inversion.
 
-`Tutorial 9: Fit Problems <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_9_fit_problems.ipynb>`_
+`Tutorial 9: Fit Problems <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_9_fit_problems.ipynb>`_
 - The shortcomings of our lens models and inversions.
 
-`Tutorial 10: Brightness Adaption <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_10_brightness_adaption.ipynb>`_
+`Tutorial 10: Brightness Adaption <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_10_brightness_adaption.ipynb>`_
 - Adapting the pixelization to the source's morphology.
 
-`Tutorial 11: Adaptive Regularization <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_11_adapt_regularization.py.ipynb>`_
+`Tutorial 11: Adaptive Regularization <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_11_adapt_regularization.py.ipynb>`_
 - Adapting the regularization to the source's morphology.

--- a/docs/howtolens/chapter_optional.rst
+++ b/docs/howtolens/chapter_optional.rst
@@ -5,9 +5,9 @@ This chapter contains optional tutorials expanding on different aspects of how *
 
 The chapter contains the following tutorials:
 
-`Tutorial: Sub-grids  <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_optional/tutorial_sub_grids.ipynb>`_
+`Tutorial: Sub-grids  <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_optional/tutorial_sub_grids.ipynb>`_
 - Use sub-grids to perform more accuratee and precise lensing calculations.
 
-`Tutorial: Searches  <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_optional/tutorial_searches.ipynb>`_
+`Tutorial: Searches  <https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_optional/tutorial_searches.ipynb>`_
 - Alternative non-linear searches to sample parameter space.
 

--- a/docs/howtolens/howtolens.rst
+++ b/docs/howtolens/howtolens.rst
@@ -3,8 +3,8 @@
 HowToLens Lectures
 ==================
 
-The best way to learn **PyAutoLens** is by going through the **HowToLens** lecture series on the
-`autolens workspace <https://github.com/Jammy2211/autolens_workspace>`_.
+The best way to learn **PyAutoLens** is by going through the **HowToLens** lecture series, which lives in its own
+repository at `PyAutoLabs/HowToLens <https://github.com/PyAutoLabs/HowToLens>`_.
 
 The lectures are provided as Jupyter notebooks (and Python scripts), and they are linked to via this readthedocs. The
 lectures are composed of five chapters
@@ -23,7 +23,8 @@ later chapters are pretty challenging, and familiarity and lens modeling is desi
 tackle them.
 
 Therefore, we recommend that you complete chapters 1 & 2 and then apply what you've learnt to the modeling of simulated
-and real strong lenses imaging, using the scripts found in the 'autolens_workspace' `modeling` packages. Once you're
+and real strong lenses imaging, using the scripts found in the
+`autolens_workspace <https://github.com/PyAutoLabs/autolens_workspace>`_ ``modeling`` packages. Once you're
 confident with your use of **PyAutoLens**, you can then begin to cover the advanced functionality covered in chapters
 3, 4 & 5.
 
@@ -57,8 +58,8 @@ Notebooks are a different way to write, view and use Python code. Compared to th
 This makes them an ideal way for us to present the HowToFit lecture series, therefore I recommend you get yourself
 a Jupyter notebook viewer (https://jupyter.org/) if you haven't done so already.
 
-If you *really* want to use Python scripts, all tutorials are supplied a .py python files in the 'scripts' folder of
-the workspace.
+If you *really* want to use Python scripts, all tutorials are also supplied as ``.py`` files in the ``scripts`` folder
+of the `HowToLens repository <https://github.com/PyAutoLabs/HowToLens>`_.
 
 Code Style and Formatting
 -------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,9 @@ The following links are useful for new starters:
 
 - `The introduction Jupyter Notebook on Colab <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb>`_, where you can try **PyAutoLens** in a web browser (without installation).
 
-- `The autolens_workspace GitHub repository <https://github.com/Jammy2211/autolens_workspace>`_, which includes example scripts and the HowToLens Jupyter notebook lectures.
+- `The autolens_workspace GitHub repository <https://github.com/PyAutoLabs/autolens_workspace>`_, which includes example scripts covering every **PyAutoLens** use case.
+
+- `The HowToLens GitHub repository <https://github.com/PyAutoLabs/HowToLens>`_: a Jupyter notebook lecture series teaching strong lensing and lens modeling from the ground up.
 
 Strong Gravitational Lensing
 ============================

--- a/docs/overview/overview_2_new_user_guide.rst
+++ b/docs/overview/overview_2_new_user_guide.rst
@@ -78,7 +78,7 @@ used in modeling and ultimately will allow you to undertake scientific research 
 To complete thoroughly, they'll probably take 2-4 days, so you may want try moving ahead to the examples but can
 go back to these lectures if you find them hard to follow.
 
-If this sounds like it suits you, checkout the `HowToLens <https://github.com/Jammy2211/autolens_workspace/tree/release/notebooks/howtolens>`_ package now.
+If this sounds like it suits you, checkout the `HowToLens <https://github.com/PyAutoLabs/HowToLens>`_ repository now.
 
 Wrap Up
 -------

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -85,9 +85,9 @@ matter, cosmology and the most distant Universe. `PyAutoLens` is an open-source 
 gravitational lensing, with core features including fully automated strong lens modeling of galaxies and galaxy 
 clusters, support for direct imaging and interferometer datasets and comprehensive tools for simulating samples of 
 strong lenses. The API allows users to perform ray-tracing by using analytic light and mass profiles to build strong 
-lens systems. Accompanying `PyAutoLens` is the [autolens workspace](https://github.com/Jammy2211/autolens_workspace), which 
-includes example scripts, lens datasets and the `HowToLens`
-lectures in Jupyter notebook format which introduce non-experts to strong lensing using `PyAutoLens`. Readers can 
+lens systems. Accompanying `PyAutoLens` is the [autolens workspace](https://github.com/PyAutoLabs/autolens_workspace), which 
+includes example scripts and lens datasets covering every use case. The [`HowToLens`](https://github.com/PyAutoLabs/HowToLens)
+repository provides a separate Jupyter notebook lecture series which introduces non-experts to strong lensing using `PyAutoLens`. Readers can 
 try `PyAutoLens` right now by going to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb) 
 or checkout the [readthedocs](https://pyautolens.readthedocs.io/en/latest/) for a complete overview of `PyAutoLens`'s features.
 
@@ -176,13 +176,14 @@ provided on how to set this up.
  
 # Workspace and HowToLens Tutorials
 
-`PyAutoLens` is distributed with the [autolens workspace](https://github.com/Jammy2211/autolens_workspace>), which 
+`PyAutoLens` is distributed with the [autolens workspace](https://github.com/PyAutoLabs/autolens_workspace), which 
 contains example scripts for modeling and simulating strong lenses and tutorials on how to preprocess imaging and 
-interferometer datasets before a `PyAutoLens` analysis. Also included are the `HowToLens` tutorials, a five chapter 
-lecture series composed of over 30 Jupyter notebooks aimed at non-experts, introducing them to strong gravitational 
-lensing, Bayesian inference and teaching them how to use `PyAutoLens` for their scientific study. The lectures 
-are available on our [Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb) and may therefore be 
-taken without a local `PyAutoLens` installation.
+interferometer datasets before a `PyAutoLens` analysis. The [`HowToLens`](https://github.com/PyAutoLabs/HowToLens)
+tutorials — a standalone repository separate from the workspace — are a five chapter lecture series composed of over
+30 Jupyter notebooks aimed at non-experts, introducing them to strong gravitational lensing, Bayesian inference and
+teaching them how to use `PyAutoLens` for their scientific study. The lectures are available on
+[Colab](https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_1_grids_and_galaxies.ipynb)
+and may therefore be taken without a local `PyAutoLens` installation.
 
 # Software Citations
 


### PR DESCRIPTION
## Summary

HowToLens has been extracted from `autolens_workspace` into its own repository at [`PyAutoLabs/HowToLens`](https://github.com/PyAutoLabs/HowToLens). This PR updates all PyAutoLens documentation, the README, and the JOSS paper to point at the new standalone repo.

- Migrates every HowToLens Colab URL from the old `autolens_workspace/notebooks/howtolens/...` path to the new `PyAutoLabs/HowToLens/blob/2026.4.13.6/notebooks/...` path (version tag matches the workspace version at extraction).
- Rewrites prose in `README.rst`, `docs/index.rst`, `docs/general/workspace.rst`, `docs/overview/overview_2_new_user_guide.rst`, `docs/howtolens/howtolens.rst`, and `paper/paper.md` to frame HowToLens as a separate repo alongside the workspace rather than a sub-folder inside it.
- Updates the per-chapter readthedocs pages (`chapter_1_introduction.rst`, `chapter_2_lens_modeling.rst`, `chapter_3_search_chaining.rst`, `chapter_4_pixelizations.rst`, `chapter_optional.rst`) so each tutorial's Colab badge resolves to the new repo.

Third of three PRs for the HowToLens extraction:
1. `PyAutoLabs/HowToLens` — initial repo, tagged `2026.4.13.6`
2. `PyAutoLabs/autolens_workspace#80` — remove the old `notebooks/howtolens/` tree and fix internal references
3. **This PR** — update PyAutoLens docs to point at the new repo

## Test plan

- [ ] readthedocs build succeeds on the branch preview
- [ ] URL-check CI (if configured) confirms every HowToLens URL resolves
- [ ] Spot-check one Colab link from each chapter loads the notebook from `PyAutoLabs/HowToLens` at tag `2026.4.13.6`

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)