### PR TITLE
Short-circuit set_snr_of_snr_light_profiles when no SNR profiles present

### DIFF
--- a/autolens/lens/tracer.py
+++ b/autolens/lens/tracer.py
@@ -1206,6 +1206,15 @@ class Tracer(ABC, ag.OperateImageGalaxies):
             The psf of the simulated imaging which can change the S/N of the light profile due to spreading out
             the emission.
         """
+        has_snr_profile = any(
+            isinstance(light_profile, LightProfileSNR)
+            for galaxies in self.planes
+            for galaxy in galaxies
+            for light_profile in galaxy.cls_list_from(cls=ag.LightProfile)
+        )
+        if not has_snr_profile:
+            return
+
         grid = aa.Grid2D.uniform(
             shape_native=grid.shape_native,
             pixel_scales=grid.pixel_scales,


### PR DESCRIPTION
## Summary

- `Tracer.set_snr_of_snr_light_profiles` previously always ray-traced the full grid before iterating galaxies to look for `LightProfileSNR` instances. Simulators using only regular light profiles (e.g. `SersicSph`, `SersicCore`) paid the full ray-tracing cost for zero benefit.
- Scan the tracer's light profiles up-front; if none are `LightProfileSNR`, return before any ray-tracing.

This was surfaced by the cluster simulator in `autolens_workspace`, which ray-traced a 1000×1000 grid through 5 dPIE profiles + an NFW halo during `via_tracer_from` — slow enough that the user Ctrl-C'd it thinking it had hung.

## API Changes

None. Public signature unchanged; early-return is a pure optimisation.

## Test plan

- [x] `python -m pytest test_autolens/lens/test_tracer.py` — 66 passed, including `test__light_profile_snr__signal_to_noise_via_simulator_correct` (confirms the SNR path still works when a `LightProfileSNR` is present).
- [x] `scripts/cluster/simulator.py` in `autolens_workspace` — previously hung in `set_snr_of_snr_light_profiles`; now passes through instantly and completes the imaging simulation (see companion PR in `autolens_workspace`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)