### PR TITLE
chore(docs): remove unused pyprojroot import

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,6 @@ import datetime
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 
-from pyprojroot import here
-
 import os
 import sys
 


### PR DESCRIPTION
## Summary
- Removes the unused `from pyprojroot import here` import from `docs/conf.py` — `here` is not referenced anywhere else in the file.

## Test plan
- [x] readthedocs build (will run automatically on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)