### PR TITLE
feat: re-export TransformerNUFFTPyNUFFT (legacy pynufft NUFFT)

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -27,6 +27,7 @@ from autoarray.inversion.mesh.border_relocator import BorderRelocator
 from autoarray.operators.convolver import Convolver
 from autoarray.operators.transformer import TransformerDFT
 from autoarray.operators.transformer import TransformerNUFFT
+from autoarray.operators.transformer import TransformerNUFFTPyNUFFT
 from autoarray.structures.arrays.uniform_1d import Array1D
 from autoarray.structures.arrays.uniform_2d import Array2D
 from autoarray.structures.arrays.rgb import Array2DRGB


### PR DESCRIPTION
## Summary

Companion to **PyAutoArray PR https://github.com/PyAutoLabs/PyAutoArray/pull/303**, which replaces `TransformerNUFFT` with a JAX-native nufftax-backed default and preserves the pynufft variant as `TransformerNUFFTPyNUFFT`.

This re-export makes the legacy class accessible as `al.TransformerNUFFTPyNUFFT` so users can opt back to the legacy gridding behaviour without reaching into autoarray directly.

One line change in `autolens/__init__.py`.

## Merge order

This PR depends on PyAutoArray PR #303 being merged first. Until that is merged, the import here will fail.

## Test plan

- [x] `pytest test_autolens/` — 273 / 273 passed
- [x] `import autolens as al; al.TransformerNUFFTPyNUFFT` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)