### PR TITLE
fix: AnalysisImaging.log_likelihood_function CPU branch returns figure_of_merit (not log_likelihood)

### DIFF
--- a/autolens/imaging/model/analysis.py
+++ b/autolens/imaging/model/analysis.py
@@ -79,7 +79,7 @@ class AnalysisImaging(AnalysisDataset):
             return self.fit_from(instance=instance).figure_of_merit - log_likelihood_penalty
 
         try:
-            return self.fit_from(instance=instance).log_likelihood - log_likelihood_penalty
+            return self.fit_from(instance=instance).figure_of_merit - log_likelihood_penalty
         except Exception as e:
             raise af.exc.FitException
 

--- a/test_autolens/imaging/model/test_analysis_imaging.py
+++ b/test_autolens/imaging/model/test_analysis_imaging.py
@@ -44,6 +44,33 @@ def test__figure_of_merit__matches_correct_fit_given_galaxy_profiles(
     assert fit.log_likelihood == analysis_log_likelihood
 
 
+def test__log_likelihood_function__returns_figure_of_merit_for_pixelization(
+    masked_imaging_7x7,
+):
+    pixelization = al.Pixelization(
+        mesh=al.mesh.RectangularUniform(shape=(3, 3)),
+        regularization=al.reg.Constant(coefficient=1.0),
+    )
+
+    lens = al.Galaxy(
+        redshift=0.5,
+        mass=al.mp.IsothermalSph(einstein_radius=1.0),
+    )
+    source = al.Galaxy(redshift=1.0, pixelization=pixelization)
+
+    model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+    instance = model.instance_from_unit_vector([])
+
+    analysis = al.AnalysisImaging(dataset=masked_imaging_7x7, use_jax=False)
+    analysis_log_likelihood = analysis.log_likelihood_function(instance=instance)
+
+    tracer = analysis.tracer_via_instance_from(instance=instance)
+    fit = al.FitImaging(dataset=masked_imaging_7x7, tracer=tracer)
+
+    assert analysis_log_likelihood == pytest.approx(fit.figure_of_merit)
+    assert fit.figure_of_merit != pytest.approx(fit.log_likelihood, rel=1e-6)
+
+
 def test__positions__likelihood_overwrites__changes_likelihood(masked_imaging_7x7):
     lens = al.Galaxy(redshift=0.5, mass=al.mp.IsothermalSph(centre=(0.05, 0.05)))
     source = al.Galaxy(redshift=1.0, light=al.lp.SersicSph(centre=(0.05, 0.05)))


### PR DESCRIPTION
## Summary

- The CPU branch of `AnalysisImaging.log_likelihood_function` returned `fit.log_likelihood` while the JAX branch returned `fit.figure_of_merit`. For pixelization (inversion) fits these differ by the regularization log-det terms of the Bayesian log evidence.
- As a result, **any nested sampler driven by the CPU path was optimising a chi²-only target instead of the log evidence** — and drifted toward `outer_coefficient ≈ 0` (noise-overfit, degenerate "no regularization" mode). JAX runs of the same model converged to the physical Bayesian-evidence maximum.
- Fix: return `fit.figure_of_merit` from both branches. For purely parametric fits this is a no-op because `figure_of_merit == log_likelihood`; for inversion fits the search now uses the mathematically correct objective.

## Test plan

- [x] New regression test `test__log_likelihood_function__returns_figure_of_merit_for_pixelization` exercises a Rectangular Pixelization with Constant regularization, asserts `analysis.log_likelihood_function(instance) == fit.figure_of_merit`, and verifies the two quantities genuinely differ (so the test isn't a tautology).
- [x] Existing `test__figure_of_merit__matches_correct_fit_given_galaxy_profiles` (parametric Sersic) still passes because `figure_of_merit == log_likelihood` when there's no inversion.
- [x] Full `test_autolens/imaging/model/test_analysis_imaging.py` passes (5/5).
- [x] End-to-end verification on a simulated lens: Nautilus + CPU sparse + 4-core converges from the degenerate mode (einstein_radius=0.997, outer_coefficient=0.000) to the physical mode (einstein_radius=1.001, outer_coefficient=95.6), matching the JAX baseline to within numerical precision.

## Impact

- All previous Nautilus / DynestyStatic / nested-sampler lens-imaging fits run on CPU with a pixelization source were optimising the wrong objective. Re-runs may produce different (correct) posteriors.
- JAX runs are unaffected — they were already using `figure_of_merit`.
- Non-pixelization (parametric-only) runs are unaffected — `figure_of_merit == log_likelihood` for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)