### PR TITLE
docs: audit-driven URL fixes across docs, READMEs, and docstrings

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -1,9 +1,9 @@
 # Citations & References
 
 The bibtex entries for **PyAutoLens** and its affiliated software packages can be found
-[here](https://github.com/Jammy2211/PyAutoLens/blob/main/files/citations.bib), with example text for citing **PyAutoLens**
-in [.tex format here](https://github.com/Jammy2211/PyAutoLens/blob/main/files/citations.tex) format here and
-[.md format here](https://github.com/Jammy2211/PyAutoLens/blob/main/files/citations.md). As shown in the examples, we
+[here](https://github.com/PyAutoLabs/PyAutoLens/blob/main/files/citations.bib), with example text for citing **PyAutoLens**
+in [.tex format here](https://github.com/PyAutoLabs/PyAutoLens/blob/main/files/citations.tex) format here and
+[.md format here](https://github.com/PyAutoLabs/PyAutoLens/blob/main/files/citations.md). As shown in the examples, we
 would greatly appreciate it if you mention **PyAutoLens** by name and include a link to our GitHub page!
 
 **PyAutoLens** is published in the [Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.02825#) and its

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -301,7 +301,7 @@ the situation is not yet resolved.
 
 ## License
 
-This code of conduct has been adapted from [*NUMFOCUS code of conduct*](https://github.com/numfocus/numfocus/blob/main/manual/numfocus-coc.md#the-short-version),
-which is adapted from numerous sources, including the [*Geek Feminism wiki, created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license*](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), the [*Contributor Covenant version 1.2.0*](http://contributor-covenant.org/version/1/2/0/), the [*Bokeh Code of Conduct*](https://github.com/bokeh/bokeh/blob/main/CODE_OF_CONDUCT.md), the [*SciPy Code of Conduct*](https://github.com/jupyter/governance/blob/main/conduct/enforcement.md), the [*Carpentries Code of Conduct*](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual), and the [*NeurIPS Code of Conduct*](https://neurips.cc/public/CodeOfConduct).
+This code of conduct has been adapted from [*NUMFOCUS code of conduct*](https://numfocus.org/code-of-conduct),
+which is adapted from numerous sources, including the [*Geek Feminism wiki, created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license*](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), the [*Contributor Covenant version 1.2.0*](http://contributor-covenant.org/version/1/2/0/), the [*Bokeh Code of Conduct*](https://github.com/bokeh/bokeh/blob/main/docs/CODE_OF_CONDUCT.md), the [*SciPy Code of Conduct*](https://github.com/jupyter/governance/blob/main/conduct/enforcement.md), the [*Carpentries Code of Conduct*](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual), and the [*NeurIPS Code of Conduct*](https://neurips.cc/public/CodeOfConduct).
 
 **PyAutoLens Code of Conduct is licensed under the [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Contributions are welcome and greatly appreciated!
 
 ### Report Bugs
 
-Report bugs at https://github.com/Jammy2211/PyAutoLens/issues
+Report bugs at https://github.com/PyAutoLabs/PyAutoLens/issues
 
 If you are playing with the PyAutoLens library and find a bug, please
 reporting it including:
@@ -86,7 +86,7 @@ reporting it including:
 ### Propose New Features
 
 The best way to send feedback is to open an issue at
-https://github.com/Jammy2211/PyAutoLens
+https://github.com/PyAutoLabs/PyAutoLens
 with tag *enhancement*.
 
 If you are proposing a nnew feature:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PyAutoLens-JAX: Open-Source Strong Lensing
 
-[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.14.2/start_here.ipynb)
+[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.14.2/notebooks/imaging/start_here.ipynb)
 [![Documentation Status](https://readthedocs.org/projects/pyautolens/badge/?version=latest)](https://pyautolens.readthedocs.io/en/latest/?badge=latest)
-[![Tests](https://github.com/Jammy2211/PyAutoLens/actions/workflows/main.yml/badge.svg)](https://github.com/Jammy2211/PyAutoLens/actions)
+[![Tests](https://github.com/PyAutoLabs/PyAutoLens/actions/workflows/main.yml/badge.svg)](https://github.com/PyAutoLabs/PyAutoLens/actions)
 [![Build](https://github.com/Jammy2211/PyAutoBuild/actions/workflows/release.yml/badge.svg)](https://github.com/Jammy2211/PyAutoBuild/actions)
 [![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![JOSS](https://joss.theoj.org/papers/10.21105/joss.02825/status.svg)](https://doi.org/10.21105/joss.02825)
@@ -14,7 +14,7 @@
 
 [Installation Guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html) |
 [readthedocs](https://pyautolens.readthedocs.io/en/latest/index.html) |
-[Introduction on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.14.2/start_here.ipynb) |
+[Introduction on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.14.2/notebooks/imaging/start_here.ipynb) |
 [HowToLens](https://pyautolens.readthedocs.io/en/latest/howtolens/howtolens.html)
 
 <img src="https://github.com/Jammy2211/PyAutoLogo/blob/main/gifs/pyautolens.gif?raw=true" width="900" />
@@ -28,7 +28,7 @@ This is called strong gravitational lensing and **PyAutoLens** makes it **simple
 The following links are useful for new starters:
 
 - [The PyAutoLens readthedocs](https://pyautolens.readthedocs.io/en/latest): which includes [an overview of PyAutoLens's core features](https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html).
-- [The introduction Jupyter Notebook on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.14.2/start_here.ipynb): try **PyAutoLens** in a web browser (without installation).
+- [The introduction Jupyter Notebook on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.14.2/notebooks/imaging/start_here.ipynb): try **PyAutoLens** in a web browser (without installation).
 - [The autolens_workspace GitHub repository](https://github.com/PyAutoLabs/autolens_workspace): example scripts covering every **PyAutoLens** use case.
 - [The HowToLens GitHub repository](https://github.com/PyAutoLabs/HowToLens): a Jupyter notebook lecture series teaching strong lensing and lens modeling from the ground up.
 
@@ -39,7 +39,7 @@ gravitational lensing analysis, and helps troubleshoot problems.
 
 Slack is invitation-only. If you'd like to join, please send an email requesting an invite.
 
-For installation issues, bug reports, or feature requests, please raise an issue on the [GitHub issues page](https://github.com/Jammy2211/PyAutoLens/issues).
+For installation issues, bug reports, or feature requests, please raise an issue on the [GitHub issues page](https://github.com/PyAutoLabs/PyAutoLens/issues).
 
 ## HowToLens
 
@@ -51,10 +51,10 @@ A complete overview of the lectures [is provided on the HowToLens readthedocs pa
 
 ## Citations
 
-Information on how to cite **PyAutoLens** in publications can be found [on the citations page](https://github.com/Jammy2211/PyAutoLens/blob/main/CITATIONS.md).
+Information on how to cite **PyAutoLens** in publications can be found [on the citations page](https://github.com/PyAutoLabs/PyAutoLens/blob/main/CITATIONS.md).
 
 ## Contributing
 
-Information on how to contribute to **PyAutoLens** can be found [on the contributing page](https://github.com/Jammy2211/PyAutoLens/blob/main/CONTRIBUTING.md).
+Information on how to contribute to **PyAutoLens** can be found [on the contributing page](https://github.com/PyAutoLabs/PyAutoLens/blob/main/CONTRIBUTING.md).
 
 Hands on support for contributions is available via our Slack workspace, again please email to request an invite.

--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -5,12 +5,12 @@ Plotting
 **PyAutoLens** custom visualization library.
 
 Step-by-step Juypter notebook guides illustrating all objects listed on this page are 
-provided on the `autolens_workspace: plot tutorials <https://github.com/Jammy2211/autolens_workspace/tree/release/notebooks/plot>`_ and
+provided on the `autolens_workspace: plot tutorials <https://github.com/PyAutoLabs/autolens_workspace/tree/main/notebooks/guides/plot>`_ and
 it is strongly recommended you use those to learn plot customization.
 
 **Examples / Tutorials:**
 
-- `autolens_workspace: plot tutorials <https://github.com/Jammy2211/autolens_workspace/tree/release/notebooks/plot>`_
+- `autolens_workspace: plot tutorials <https://github.com/PyAutoLabs/autolens_workspace/tree/main/notebooks/guides/plot>`_
 
 Plotters [aplt]
 ---------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import datetime
 #
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
-# https://www.sphinx-doc.org/en/main/usage/configuration.html
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
 
@@ -65,7 +65,7 @@ extlinks = {"pypi": ("https://pypi.org/project/%s/", "")}
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "sphinx": ("https://www.sphinx-doc.org/en/main", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
 }
 
 # -- Options for TODOs -------------------------------------------------------

--- a/docs/general/citations.md
+++ b/docs/general/citations.md
@@ -3,9 +3,9 @@
 # Citations & References
 
 The bibtex entries for **PyAutoLens** and its affiliated software packages can be found
-[here](https://github.com/Jammy2211/PyAutoLens/blob/main/files/citations.bib), with example text for citing **PyAutoLens**
-in [.tex format here](https://github.com/Jammy2211/PyAutoLens/blob/main/files/citations.tex) format here and
-[.md format here](https://github.com/Jammy2211/PyAutoLens/blob/main/files/citations.md). As shown in the examples, we
+[here](https://github.com/PyAutoLabs/PyAutoLens/blob/main/files/citations.bib), with example text for citing **PyAutoLens**
+in [.tex format here](https://github.com/PyAutoLabs/PyAutoLens/blob/main/files/citations.tex) format here and
+[.md format here](https://github.com/PyAutoLabs/PyAutoLens/blob/main/files/citations.md). As shown in the examples, we
 would greatly appreciate it if you mention **PyAutoLens** by name and include a link to our GitHub page!
 
 **PyAutoLens** is published in the [Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.02825#) and its

--- a/docs/general/configs.md
+++ b/docs/general/configs.md
@@ -4,7 +4,7 @@
 visualization and other aspects of **PyAutoLens**.
 
 Descriptions of every configuration file and their input parameters are provided in the `README.md` in
-the [config directory of the workspace](https://github.com/Jammy2211/autolens_workspace/tree/release/config)
+the [config directory of the workspace](https://github.com/PyAutoLabs/autolens_workspace/tree/main/config)
 
 ## Setup
 

--- a/docs/general/credits.md
+++ b/docs/general/credits.md
@@ -6,7 +6,7 @@
 
 [James Nightingale](https://github.com/Jammy2211): Lead developer & PyAutoLens guru.
 
-[Richard Hayes](https://github.com/rhayes777): Lead developer & [PyAutoFit](https://github.com/rhayes777/PyAutoFit) guru.
+[Richard Hayes](https://github.com/rhayes777): Lead developer & [PyAutoFit](https://github.com/PyAutoLabs/PyAutoFit) guru.
 
 [Aristeidis Amvrosiadis](https://github.com/Sketos): Interferometer Analysis.
 

--- a/docs/general/demagnified_solutions.md
+++ b/docs/general/demagnified_solutions.md
@@ -10,12 +10,12 @@ models to be estimated.
 This is due to demagnified source reconstructions, where the source is reconstructed as the lensed source galaxy
 (without any lensing):
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/general/images/data.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/general/images/data.png
 :alt: Alternative text
 :width: 400
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/general/images/model_image.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/general/images/model_image.png
 :alt: Alternative text
 :width: 400
 ```
@@ -30,14 +30,14 @@ models with **too much mass**, such that the ray-tracing inverts in on itself.
 The following schematic is from the paper Maresca et al 2021 (<https://arxiv.org/abs/2012.04665>) and illustrates
 this beautifully:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/general/images/maresca_fig1.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/general/images/maresca_fig1.png
 :alt: Alternative text
 :width: 400
 ```
 
 The source reconstructions and model-fits of these solutions are also illustrated by Maresca et al 2021:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/general/images/maresca_fig2.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/general/images/maresca_fig2.png
 :alt: Alternative text
 :width: 400
 ```
@@ -64,13 +64,13 @@ positions = al.Grid2DIrregular(
 Here is where the multiple images appear for an example strong lens, where multiple images are drawn on with black
 stars:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/general/images/lensed_source.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/general/images/lensed_source.png
 :alt: Alternative text
 :width: 400
 ```
 
 The `autolens_workspace` also includes a Graphical User Interface for drawing lensed source positions via
-mouse click (<https://github.com/Jammy2211/autolens_workspace/blob/release/scripts/imaging/preprocess/gui/positions.py>).
+mouse click (<https://github.com/PyAutoLabs/autolens_workspace/blob/main/scripts/imaging/preprocess/gui/positions.py>).
 
 Next, we create `PositionsLH` object, which has an input `threshold`.
 

--- a/docs/general/model_cookbook.md
+++ b/docs/general/model_cookbook.md
@@ -372,8 +372,8 @@ profiles.
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/Jammy2211/autolens_workspace/blob/release/notebooks/modeling/imaging/features/multi_gaussian_expansion.ipynb>
-<https://github.com/Jammy2211/autolens_workspace/blob/release/notebooks/modeling/imaging/features/shapelets.ipynb>
+<https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/imaging/features/multi_gaussian_expansion/modeling.ipynb>
+<https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/imaging/features/advanced/shapelets/modeling.ipynb>
 
 ## Model Linking (Advanced)
 
@@ -381,7 +381,7 @@ When performing non-linear search chaining, the inferred model of one phase can 
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/Jammy2211/autolens_workspace/blob/release/notebooks/imaging/advanced/chaining/start_here.ipynb>
+<https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/imaging/advanced/chaining/start_here.ipynb>
 
 ## Across Datasets (Advanced)
 
@@ -390,7 +390,7 @@ but certain parameters are free to vary across the datasets.
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/Jammy2211/autolens_workspace/blob/release/notebooks/multi/modeling/start_here.ipynb>
+<https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/multi/start_here.ipynb>
 
 ## Relations (Advanced)
 
@@ -399,7 +399,7 @@ We can compose models where the free parameter(s) vary according to a user-speci
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/Jammy2211/autolens_workspace/blob/release/notebooks/multi/modeling/features/wavelength_dependence.ipynb>
+<https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/multi/features/wavelength_dependence/modeling.ipynb>
 
 ## PyAutoFit API
 

--- a/docs/general/workspace.md
+++ b/docs/general/workspace.md
@@ -2,7 +2,7 @@
 
 # Workspace Tour
 
-You should have downloaded and configured the [autolens workspace](https://github.com/Jammy2211/autolens_workspace)
+You should have downloaded and configured the [autolens workspace](https://github.com/PyAutoLabs/autolens_workspace)
 when you installed **PyAutoLens**. If you didn't, checkout the
 [installation instructions](https://pyautolens.readthedocs.io/en/latest/general/installation.html#installation-with-pip)
 for how to downloaded and configure the workspace.
@@ -18,7 +18,7 @@ There are numerous example describing how to perform lensing calculations, lens 
 **PyAutoLens** features. All examples are provided as Python scripts and Jupyter notebooks.
 
 Descriptions of every configuration file and their input parameters are provided in the `README.md` in
-the [config directory of the workspace](https://github.com/Jammy2211/autolens_workspace/tree/release/config)
+the [config directory of the workspace](https://github.com/PyAutoLabs/autolens_workspace/tree/main/config)
 
 ## Config
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ This is called strong gravitational lensing and **PyAutoLens** makes it simple t
 The following links are useful for new starters:
 
 - [The PyAutoLens readthedocs](https://pyautolens.readthedocs.io/en/latest): which includes [an overview of PyAutoLens's core features](https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html).
-- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.14.2/start_here.ipynb), where you can try **PyAutoLens** in a web browser (without installation).
+- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.14.2/notebooks/imaging/start_here.ipynb), where you can try **PyAutoLens** in a web browser (without installation).
 - [The autolens_workspace GitHub repository](https://github.com/PyAutoLabs/autolens_workspace), which includes example scripts covering every **PyAutoLens** use case.
 - [The HowToLens GitHub repository](https://github.com/PyAutoLabs/HowToLens): a Jupyter notebook lecture series teaching strong lensing and lens modeling from the ground up.
 
@@ -28,7 +28,7 @@ imaged source galaxy whose light has been distorted into an 'Einstein ring'. The
 reconstructions of the source's lensed and unlensed light distributions, which are created using a model of the lens
 galaxy's mass to trace backwards how the source's light is gravitationally lensed.
 
-```{image} https://github.com/Jammy2211/PyAutoLens/blob/main/files/imageaxis.png?raw=true
+```{image} https://github.com/PyAutoLabs/PyAutoLens/blob/main/files/imageaxis.png?raw=true
 ```
 
 Strong lensing provides astronomers with an invaluable tool to study a diverse range of topics, including the
@@ -109,7 +109,7 @@ tracer_plotter.figures_2d(image=True)
 ```
 
 To perform lens modeling, **PyAutoLens** adopts the probabilistic programming
-language [PyAutoFit](https://github.com/rhayes777/PyAutoFit). **PyAutoFit** allows users to compose a
+language [PyAutoFit](https://github.com/PyAutoLabs/PyAutoFit). **PyAutoFit** allows users to compose a
 lens model from `LightProfile`, `MassProfile` and `Galaxy` objects, customize the model parameterization and
 fit it to data via a non-linear search (e.g. [dynesty](https://github.com/joshspeagle/dynesty),
 [emcee](https://github.com/dfm/emcee) or [PySwarms](https://pyswarms.readthedocs.io/en/latest/)). The example
@@ -194,7 +194,7 @@ datasets.
 For new **PyAutoLens** users, we recommend they start by
 [installing PyAutoLens](https://pyautolens.readthedocs.io/en/latest/installation/overview.html) (if you haven't
 already!), read through the `start_here.ipynb` notebook on
-the [autolens_workspace](https://github.com/Jammy2211/autolens_workspace) and take the
+the [autolens_workspace](https://github.com/PyAutoLabs/autolens_workspace) and take the
 [HowToLens Jupyter notebook lecture series](https://pyautolens.readthedocs.io/en/latest/howtolens/howtolens.html) on
 strong gravitational lensing.
 

--- a/docs/installation/conda.md
+++ b/docs/installation/conda.md
@@ -66,7 +66,7 @@ the `autolens_workspace`, reducing the download size):
 
 ```bash
 cd /path/on/your/computer/you/want/to/put/the/autolens_workspace
-git clone https://github.com/Jammy2211/autolens_workspace --depth 1
+git clone https://github.com/PyAutoLabs/autolens_workspace --depth 1
 cd autolens_workspace
 ```
 

--- a/docs/installation/overview.md
+++ b/docs/installation/overview.md
@@ -34,10 +34,10 @@ If you install **PyAutoLens** without a proper GPU setup, a warning will be disp
 
 **PyAutoLens** uses the following parent packages:
 
-**PyAutoConf** <https://github.com/rhayes777/PyAutoConf>
+**PyAutoConf** <https://github.com/PyAutoLabs/PyAutoConf>
 
-**PyAutoFit** <https://github.com/rhayes777/PyAutoFit>
+**PyAutoFit** <https://github.com/PyAutoLabs/PyAutoFit>
 
-**PyAutoArray** <https://github.com/Jammy2211/PyAutoArray>
+**PyAutoArray** <https://github.com/PyAutoLabs/PyAutoArray>
 
-**PyAutoGalaxy** <https://github.com/Jammy2211/PyAutoGalaxy>
+**PyAutoGalaxy** <https://github.com/PyAutoLabs/PyAutoGalaxy>

--- a/docs/installation/pip.md
+++ b/docs/installation/pip.md
@@ -53,7 +53,7 @@ the `autolens_workspace`, reducing the download size):
 
 ```bash
 cd /path/on/your/computer/you/want/to/put/the/autolens_workspace
-git clone https://github.com/Jammy2211/autolens_workspace --depth 1
+git clone https://github.com/PyAutoLabs/autolens_workspace --depth 1
 cd autolens_workspace
 ```
 

--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -22,11 +22,11 @@ contribute the development **PyAutoLens** or experiment with yourself!
 
 A large amount of **PyAutoLens** functionality is contained in its parent projects:
 
-**PyAutoFit** <https://github.com/rhayes777/PyAutoFit>
+**PyAutoFit** <https://github.com/PyAutoLabs/PyAutoFit>
 
-**PyAutoArray** <https://github.com/Jammy2211/PyAutoArray>
+**PyAutoArray** <https://github.com/PyAutoLabs/PyAutoArray>
 
-**PyAutoGalaxy** <https://github.com/Jammy2211/PyAutoGalaxy>
+**PyAutoGalaxy** <https://github.com/PyAutoLabs/PyAutoGalaxy>
 
 If you wish to build from source all code you may need to build from source these 3 additional
 projects. We include below instructions for building just **PyAutoLens** from source or building all projects.
@@ -42,7 +42,7 @@ pip install --upgrade pip
 First, clone (or fork) the **PyAutoLens** GitHub repository:
 
 ```bash
-git clone https://github.com/Jammy2211/PyAutoLens
+git clone https://github.com/PyAutoLabs/PyAutoLens
 ```
 
 Next, install the **PyAuto** parent projects via pip:
@@ -105,10 +105,10 @@ pip install --upgrade pip
 First, clone (or fork) all 4 GitHub repositories:
 
 ```bash
-git clone https://github.com/rhayes777/PyAutoFit
-git clone https://github.com/Jammy2211/PyAutoArray
-git clone https://github.com/Jammy2211/PyAutoGalaxy
-git clone https://github.com/Jammy2211/PyAutoLens
+git clone https://github.com/PyAutoLabs/PyAutoFit
+git clone https://github.com/PyAutoLabs/PyAutoArray
+git clone https://github.com/PyAutoLabs/PyAutoGalaxy
+git clone https://github.com/PyAutoLabs/PyAutoLens
 ```
 
 Next, install **PyAutoConf** via pip:

--- a/docs/installation/troubleshooting.md
+++ b/docs/installation/troubleshooting.md
@@ -21,7 +21,7 @@ instead, or visa versa.
 ## Support
 
 If you are still having issues with installation, please raise an issue on the
-[autolens_workspace issues page](https://github.com/Jammy2211/autolens_workspace/issues) with a description of the
+[autolens_workspace issues page](https://github.com/PyAutoLabs/autolens_workspace/issues) with a description of the
 problem and your system setup (operating system, Python version, etc.).
 
 ## Current Working Directory

--- a/docs/overview/overview_1_start_here.md
+++ b/docs/overview/overview_1_start_here.md
@@ -9,7 +9,7 @@ It uses **JAX** to **accelerate lensing calculations**, with the example code be
 
 Here is a schematic of a strong gravitational lens:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/schematic.jpg
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/schematic.jpg
 :alt: Alternative text
 :width: 600
 ```
@@ -52,7 +52,7 @@ aplt.plot_grid(grid=grid, title="")
 
 The `Grid2D` looks like this:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/0_grid.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/0_grid.png
 :alt: Alternative text
 :width: 600
 ```
@@ -103,7 +103,7 @@ for fits to large datasets.
 aplt.plot_array(array=sersic_light_profile.image_2d_from(grid=grid), title="Image")
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/1_image_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/1_image_2d.png
 :alt: Alternative text
 :width: 600
 ```
@@ -144,12 +144,12 @@ aplt.plot_array(array=isothermal_mass_profile.convergence_2d_from(grid=grid), ti
 aplt.plot_array(array=isothermal_mass_profile.potential_2d_from(grid=grid), title="Potential")
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/2_deflections_y_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/2_deflections_y_2d.png
 :alt: Alternative text
 :width: 600
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/3_deflections_x_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/3_deflections_x_2d.png
 :alt: Alternative text
 :width: 600
 ```
@@ -192,22 +192,22 @@ aplt.plot_array(array=lens_galaxy.image_2d_from(grid=grid), title="Lens Galaxy I
 aplt.plot_array(array=source_galaxy.image_2d_from(grid=grid), title="Source Galaxy Image")
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/4_image_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/4_image_2d.png
 :alt: Alternative text
 :width: 400
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/7_image_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/7_image_2d.png
 :alt: Alternative text
 :width: 400
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/5_deflections_y_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/5_deflections_y_2d.png
 :alt: Alternative text
 :width: 400
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/6_deflections_x_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/6_deflections_x_2d.png
 :alt: Alternative text
 :width: 400
 ```
@@ -218,7 +218,7 @@ The individual light profiles of the galaxy can be plotted on a subplot:
 aplt.subplot_galaxy_light_profiles(galaxy=lens_galaxy, grid=grid)
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/8_subplot_image.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/8_subplot_image.png
 :alt: Alternative text
 :width: 600
 ```
@@ -240,7 +240,7 @@ tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy], cosmology=al.cosmo.Pla
 aplt.plot_array(array=tracer.image_2d_from(grid=grid), title="Image")
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/9_image_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/9_image_2d.png
 :alt: Alternative text
 :width: 600
 ```
@@ -324,7 +324,7 @@ tracer = al.Tracer(galaxies=[lens_galaxy_0, lens_galaxy_1, source_galaxy])
 aplt.plot_array(array=tracer.image_2d_from(grid=grid), title="Image")
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1/10_image_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1/10_image_2d.png
 :alt: Alternative text
 :width: 600
 ```

--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -17,18 +17,18 @@ There are three scales to choose from:
 - **Galaxy Scale**: Made up of a single lens galaxy lensing a single source galaxy, the simplest strong lens you can get!
   If you're interested in galaxy scale lenses, go to the question below called "What Data Type?".
 - **Group Scale**: Strong Lens Groups contains 2-10 lens galaxies, normally with one main large galaxy responsible for the majority of lensing.
-  They also typically lens just one source galaxy. If you are interested in groups, go to the [group/start_here.ipynb](https://github.com/Jammy2211/autolens_workspace/blob/release/notebooks/group/start_here.ipynb) notebook.
+  They also typically lens just one source galaxy. If you are interested in groups, go to the [group/start_here.ipynb](https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/group/start_here.ipynb) notebook.
 - **Cluster Scale**: Strong Lens Galaxy clusters often contained 20-50, or more, lens galaxies, lensing 10, or more, sources galaxies.
-  If you are interested in clusters, go to the [cluster/start_here.ipynb](https://github.com/Jammy2211/autolens_workspace/blob/release/notebooks/cluster/start_here.ipynb) notebook.
+  If you are interested in clusters, go to the [cluster/start_here.ipynb](https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/cluster/start_here.ipynb) notebook.
 
 ## What Dataset Type?
 
 If you are interested in galaxy-scale strong lenses, you now need to decide what type of strong lens data you are
 interested in:
 
-- **CDD Imaging**: For image data from telescopes like Hubble and James Webb, go to [imaging/start_here.ipynb](https://github.com/Jammy2211/autolens_workspace/blob/release/notebooks/imaging/start_here.ipynb).
-- **Interferometer**: For radio / sub-mm interferometer from instruments like ALMA, go to [interferometer/start_here.ipynb](https://github.com/Jammy2211/autolens_workspace/blob/release/notebooks/interferometer/start_here.ipynb).
-- **Point Sources**: For strongly lensed point sources (e.g. lensed quasars, supernovae), go to [point_source/start_here.ipynb](hhttps://github.com/Jammy2211/autolens_workspace/blob/release/notebooks/point_source/start_here.ipynb).
+- **CDD Imaging**: For image data from telescopes like Hubble and James Webb, go to [imaging/start_here.ipynb](https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/imaging/start_here.ipynb).
+- **Interferometer**: For radio / sub-mm interferometer from instruments like ALMA, go to [interferometer/start_here.ipynb](https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/interferometer/start_here.ipynb).
+- **Point Sources**: For strongly lensed point sources (e.g. lensed quasars, supernovae), go to [point_source/start_here.ipynb](https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/point_source/start_here.ipynb).
 
 ## Google Colab
 

--- a/docs/overview/overview_3_features.md
+++ b/docs/overview/overview_3_features.md
@@ -36,7 +36,7 @@ The image below shows a pixelized source reconstruction of the strong lens SLACS
 reconstructed on a Voronoi mesh adapted to the source morphology, revealing it to be a grand-design face on spiral
 galaxy:
 
-```{image} https://github.com/Jammy2211/PyAutoLens/blob/main/files/imageaxis.png?raw=true
+```{image} https://github.com/PyAutoLabs/PyAutoLens/blob/main/files/imageaxis.png?raw=true
 :alt: Alternative text
 :width: 600
 ```
@@ -58,27 +58,27 @@ surface brightness distribution.
 Instead, we assume that our source is a point source with a centre (y,x), and ray-trace triangles at iteratively
 higher resolutions to determine the source's exact locations in the image-plane:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/point_0.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/point_0.png
 :alt: Alternative text
 :width: 400
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/point_1.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/point_1.png
 :alt: Alternative text
 :width: 400
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/point_2.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/point_2.png
 :alt: Alternative text
 :width: 400
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/point_3.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/point_3.png
 :alt: Alternative text
 :width: 400
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/point_4.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/point_4.png
 :alt: Alternative text
 :width: 400
 ```
@@ -92,7 +92,7 @@ Checkout the `autolens_workspace/*/point_source` package to get started.
 
 Modeling of interferometer data from submillimeter (e.g. ALMA) and radio (e.g. LOFAR) observatories:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/paper/almacombined.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/paper/almacombined.png
 :alt: Alternative text
 :width: 600
 ```
@@ -107,7 +107,7 @@ Checkout the `autolens_workspace/*/interferometer` package to get started.
 
 An MGE decomposes the light of a galaxy into tens or hundreds of two dimensional Gaussians:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/mge.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/mge.png
 :alt: Alternative text
 :width: 600
 ```
@@ -131,7 +131,7 @@ Checkout `autolens_workspace/notebooks/features/multi_gaussian_expansion.ipynb` 
 The strong lenses we've discussed so far have just a single lens galaxy responsible for the lensing. Group-scale
 strong lenses are systems where there two or more lens galaxies deflecting one or more background sources:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/group.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/group.png
 :alt: Alternative text
 :width: 600
 ```
@@ -147,12 +147,12 @@ The `autolens_workspace/*/group` package has example scripts for simulating data
 Modeling imaging datasets observed at different wavelengths (e.g. HST F814W and F150W) simultaneously or simultaneously
 analysing imaging and interferometer data:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/g_image.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/g_image.png
 :alt: Alternative text
 :width: 600
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/r_image.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/r_image.png
 :alt: Alternative text
 :width: 600
 ```
@@ -169,7 +169,7 @@ feature and it is recommended you first get to grips with the core API.
 Ellipse fitting is a technique which fits many ellipses to a galaxy's emission to determine its ellipticity, position
 angle and centre, without assuming a parametric form for its light (e.g. like a Seisc profile):
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/ellipse.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/ellipse.png
 :alt: Alternative text
 :width: 600
 ```
@@ -188,7 +188,7 @@ Checkout `autolens_workspace/notebooks/features/ellipse_fitting.ipynb` to learn 
 
 Shapelets are a set of orthogonal basis functions that can be combined the represent galaxy structures:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/shapelets.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/shapelets.png
 :alt: Alternative text
 :width: 600
 ```

--- a/files/citations.md
+++ b/files/citations.md
@@ -1,6 +1,6 @@
 **Insert in the main body of the paper:**
 
-We use the lens modeling software `PyAutoLens` https://github.com/Jammy2211/PyAutoLens) [@pyautolens] [@Nightingale2015] [@Nightingale2018] to...
+We use the lens modeling software `PyAutoLens` https://github.com/PyAutoLabs/PyAutoLens) [@pyautolens] [@Nightingale2015] [@Nightingale2018] to...
 
 **At the end of the paper (delete as appropriate, see https://pyautofit.readthedocs.io/en/latest/general/citations.html):**
 
@@ -16,9 +16,9 @@ This work uses the following software packages:
 - `matplotlib` https://github.com/matplotlib/matplotlib [@matplotlib]
 - `numba` https://github.com/numba/numba [@numba]
 - `NumPy` https://github.com/numpy/numpy [@numpy]
-- `PyAutoFit` https://github.com/rhayes777/PyAutoFit [@pyautofit]
-- `PyAutoGalaxy` https://github.com/Jammy2211/PyAutoGalaxy [@Nightingale2018] [@pyautogalaxy]
-- `PyAutoLens` https://github.com/Jammy2211/PyAutoLens [@Nightingale2015] [@Nightingale2018] [@pyautolens]
+- `PyAutoFit` https://github.com/PyAutoLabs/PyAutoFit [@pyautofit]
+- `PyAutoGalaxy` https://github.com/PyAutoLabs/PyAutoGalaxy [@Nightingale2018] [@pyautogalaxy]
+- `PyAutoLens` https://github.com/PyAutoLabs/PyAutoLens [@Nightingale2015] [@Nightingale2018] [@pyautolens]
 - `PyNUFFT` https://github.com/jyhmiinlin/pynufft [@pynufft]
 - `PySwarms` https://github.com/ljvmiranda921/pyswarms [@pyswarms]
 - `Python` https://www.python.org/ [@python]

--- a/paper/README.md
+++ b/paper/README.md
@@ -1,5 +1,5 @@
 PyAutoLens JOSS Paper
 =====================
 
-Paper accompanying [PyAutoGalaxy](https://github.com/rhayes777/PyAutoGalaxy) for submission to the Journal of Open Source 
+Paper accompanying [PyAutoGalaxy](https://github.com/PyAutoLabs/PyAutoGalaxy) for submission to the Journal of Open Source 
 Software (JOSS).

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -72,7 +72,7 @@ affiliations:
     index: 7
 
 date: 25 January 2022
-codeRepository: https://github.com/Jammy2211/PyAutoLens
+codeRepository: https://github.com/PyAutoLabs/PyAutoLens
 license: MIT
 bibliography: paper.bib
 ---
@@ -88,7 +88,7 @@ strong lenses. The API allows users to perform ray-tracing by using analytic lig
 lens systems. Accompanying `PyAutoLens` is the [autolens workspace](https://github.com/PyAutoLabs/autolens_workspace), which 
 includes example scripts and lens datasets covering every use case. The [`HowToLens`](https://github.com/PyAutoLabs/HowToLens)
 repository provides a separate Jupyter notebook lecture series which introduces non-experts to strong lensing using `PyAutoLens`. Readers can 
-try `PyAutoLens` right now by going to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.14.2/start_here.ipynb) 
+try `PyAutoLens` right now by going to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.14.2/notebooks/imaging/start_here.ipynb) 
 or checkout the [readthedocs](https://pyautolens.readthedocs.io/en/latest/) for a complete overview of `PyAutoLens`'s features.
 
 # Background
@@ -137,7 +137,7 @@ extensible, making it straightforward to compose highly customized lensing syste
 optimized using the packages `NumPy` [@numpy], `numba` [@numba] and `pyquad` [@pyquad].
 
 To perform lens modeling, `PyAutoLens` adopts the probabilistic programming 
-language `PyAutoFit` (https://github.com/rhayes777/PyAutoFit). `PyAutoFit` allows users to compose a 
+language `PyAutoFit` (https://github.com/PyAutoLabs/PyAutoFit). `PyAutoFit` allows users to compose a 
 lens model from `LightProfile`, `MassProfile` and `Galaxy` objects, customize the model parameterization and fit it to 
 data via a non-linear search (e.g., `dynesty` [@dynesty], `emcee` [@emcee], `PySwarms` [@pyswarms]). By composing a 
 lens model with a `Pixelization`  object, the background source's light is reconstructed using a 
@@ -149,7 +149,7 @@ Automated lens modeling uses `PyAutoFit`'s non-linear search chaining feature, w
 a chained sequence of non-linear searches. These fits pass information gained about simpler lens models fitted by earlier 
 searches to subsequent searches, which fit progressively more complex models. By granularizing the model-fitting 
 procedure, automated pipelines that fit complex lens models without human intervention can be carefully crafted, with 
-example pipelines found on the [autolens workspace](https://github.com/Jammy2211/autolens_workspace). To ensure the 
+example pipelines found on the [autolens workspace](https://github.com/PyAutoLabs/autolens_workspace). To ensure the 
 analysis and interpretation of fits to large lens datasets is feasible, `PyAutoFit`'s database tools write lens modeling 
 results to a relational database which can be queried from hard-disk to a Python script or Jupyter notebook. This uses 
 memory-light `Python` generators, ensuring it is practical for thousands of lenses.


### PR DESCRIPTION
## Summary

Doc-only URL cleanup driven by the new `admin_jammy/software/url_check/` audit tool (Jammy2211/admin_jammy#21). Fixes the user-reported `hhttps://` typo in `overview_2_new_user_guide.md` plus ~20 mechanical URL rewrites covering:

- Renamed GitHub orgs: `Jammy2211/<workspace>` → `PyAutoLabs/<workspace>`; `Jammy2211|rhayes777/<library>` → `PyAutoLabs/<library>`
- Removed `release` branch on workspaces: `/blob/release/` → `/blob/main/`, `/tree/release/` → `/tree/main/`
- nautilus sampler moved orgs: `joshspeagle/nautilus` → `johannesulf/nautilus`
- PyAutoBuild moved orgs: `rhayes777/PyAutoBuild` → `PyAutoLabs/PyAutoBuild`
- Dead Code of Conduct links: bokeh CoC → `/docs/CODE_OF_CONDUCT.md`; numfocus → `numfocus.org/code-of-conduct`
- Sphinx-doc: `/en/main` → `/en/master`
- pyautofit.readthedocs.io renames: `cookbook_1_basics` → `cookbooks/model`, `overview/model_fit` → `overview/the_basics`, `overview/result` → `cookbooks/result`, etc.
- Workspace notebook reorganisations: `overview/simple/fit.ipynb` → `overview/overview_1_the_basics.ipynb`, `modeling/imaging/features/<x>.ipynb` → `imaging/features/<x>/modeling.ipynb`, etc.
- Colab badge URL: workspace-root `start_here.ipynb` → `notebooks/<type>/start_here.ipynb` (the bare-root file never existed)

No source-code behaviour changes — only docstring and `.md / .rst / Python-comment` text. CRLF line endings preserved (no whitespace churn).

## Test plan

- [x] `python -m pytest test_<library>` passes
- [x] `python -c "import <library>"` succeeds (verifies docstring edits don't break parsing)
- [ ] Audit re-run after this PR + paired PRs merge

## Related

- Tool PR: Jammy2211/admin_jammy#21
- Issue: PyAutoLabs/PyAutoLens#508
- Workspace-phase follow-up: HowToFit, HowToGalaxy, HowToLens, autofit_workspace, autogalaxy_workspace, autolens_workspace (URLs in symlinked workspace files were SCANNED but not FIXED in this phase)