### PR TITLE
docs: add autolens_assistant prototype callout to README and docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ When two or more galaxies are aligned perfectly down our line-of-sight, the back
 
 This is called strong gravitational lensing and **PyAutoLens** makes it **simple** to model strong gravitational lenses, using JAX to **accelerate lens modeling on GPUs**.
 
+> 🤖 **Prototype:** [**autolens_assistant**](https://github.com/PyAutoLabs/autolens_assistant) is an early-stage AI assistant you talk to in natural language to do lens modeling end-to-end. It is experimental and **not the recommended starting point** — the readthedocs, autolens_workspace, and HowToLens below remain the canonical entry points. Try it if you'd like to drive PyAutoLens by conversation.
+
 ## Getting Started
 
 The following links are useful for new starters:

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,10 @@ When two or more galaxies are aligned perfectly down our line-of-sight, the back
 
 This is called strong gravitational lensing and **PyAutoLens** makes it simple to model strong gravitational lenses, using JAX to **accelerate lens modeling on GPUs**.
 
+```{note}
+🤖 **Prototype:** [autolens_assistant](https://github.com/PyAutoLabs/autolens_assistant) is an early-stage AI assistant you talk to in natural language to do lens modeling end-to-end. It is experimental and **not the recommended starting point** — the readthedocs, autolens_workspace, and HowToLens below remain the canonical entry points. Try it if you'd like to drive PyAutoLens by conversation.
+```
+
 # Getting Started
 
 The following links are useful for new starters:


### PR DESCRIPTION
## Summary

Adds a prominent but prototype-flagged pointer to the new [\`PyAutoLabs/autolens_assistant\`](https://github.com/PyAutoLabs/autolens_assistant) repo near the top of:

- \`README.md\` (between the opening explainer and \`## Getting Started\`)
- \`docs/index.md\` (same placement, using a MyST \`{note}\` admonition for RTD styling)

The callout explicitly tells users the readthedocs / autolens_workspace / HowToLens links remain the canonical starting points. The assistant is offered only for users who'd like to drive PyAutoLens by natural-language conversation.

Companion PR: PyAutoLabs/autolens_assistant#4

## Test plan

- [ ] RTD build renders the \`{note}\` admonition correctly on docs/index.md.
- [ ] GitHub renders the blockquote-style callout in README.md.
- [x] Both callouts sit above existing "Getting Started" links, but text is clear that those links remain the recommended path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)