### PR TITLE
feat: simulate_substructure end-to-end jittable simulator

### DIFF
--- a/autolens/lens/substructure_util.py
+++ b/autolens/lens/substructure_util.py
@@ -120,3 +120,51 @@ def traced_grids_via_scan(
     _, traced_grids = jax.lax.scan(scan_step, init_carry, plane_stack)
 
     return traced_grids
+
+
+def simulate_substructure(
+    grid,
+    image_shape,
+    halo_params,
+    halo_mask,
+    scaling_matrix,
+    macro_deflections_fn,
+    macro_plane_mask,
+    sheet_kappas,
+    source_image_fn,
+    psf_kernel,
+    exposure_time,
+    background_sky_level,
+    prng_key,
+    halo_profile_cls,
+):
+    import jax
+    import jax.numpy as jnp
+
+    traced_grids = traced_grids_via_scan(
+        grid=grid,
+        halo_params=halo_params,
+        halo_mask=halo_mask,
+        scaling_matrix=scaling_matrix,
+        macro_deflections_fn=macro_deflections_fn,
+        macro_plane_mask=macro_plane_mask,
+        sheet_kappas=sheet_kappas,
+        halo_profile_cls=halo_profile_cls,
+    )
+
+    source_grid = traced_grids[-1]
+    image_1d = source_image_fn(source_grid)
+    image_2d = image_1d.reshape(image_shape)
+
+    image_2d = jax.scipy.signal.fftconvolve(image_2d, psf_kernel, mode="same")
+
+    image_2d = image_2d + background_sky_level
+
+    if prng_key is not None:
+        image_counts = image_2d * exposure_time
+        noisy_counts = jax.random.poisson(prng_key, image_counts)
+        image_2d = noisy_counts / exposure_time - background_sky_level
+    else:
+        image_2d = image_2d - background_sky_level
+
+    return image_2d


### PR DESCRIPTION
## Summary

- Adds `simulate_substructure` to `autolens/lens/substructure_util.py` — a pure jnp function that chains scan-based multi-plane ray-tracing (prompt 2), source light evaluation, FFT PSF convolution, and Poisson noise via `jax.random.PRNGKey`
- Supports `prng_key=None` to skip noise for deterministic comparisons
- The complete `theta -> noisy_image` pipeline compiles under `jax.jit`

## API

```python
from autolens.lens.substructure_util import simulate_substructure

image = simulate_substructure(
    grid, image_shape, halo_params, halo_mask, scaling_matrix,
    macro_deflections_fn, macro_plane_mask, sheet_kappas,
    source_image_fn, psf_kernel, exposure_time, background_sky_level,
    prng_key=jax.random.PRNGKey(42),
    halo_profile_cls=ag.mp.NFWTruncatedSph,
)
```

## Test plan

- [x] Pre-convolution lensed image matches existing Tracer path (atol=1e-4)
- [x] `jax.jit(simulate_substructure)` compiles and matches eager result
- [x] Poisson noise produces different, non-NaN image vs clean
- [x] Different PRNGKeys produce different noise realizations
- [ ] Companion PR: autolens_workspace_test#128

Ref: PyAutoLens#542 (prompt 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)