### PR TITLE
fix(jax): defensive pytree dedup in imaging/interferometer analyses

### DIFF
--- a/autolens/imaging/model/analysis.py
+++ b/autolens/imaging/model/analysis.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 logger.setLevel(level="INFO")
 
 
+_FIT_IMAGING_PYTREES_REGISTERED = False
+
+
 class AnalysisImaging(AnalysisDataset):
 
     Result = ResultImaging
@@ -174,10 +177,37 @@ class AnalysisImaging(AnalysisDataset):
         analysis — ride as aux so JAX does not recurse into them. Everything
         else (``tracer``, ``dataset_model`` and the autoarray wrappers they
         carry) is dynamic per fit.
+
+        Idempotent — guarded by the module-level
+        ``_FIT_IMAGING_PYTREES_REGISTERED`` flag. ``DatasetModel`` and
+        ``Tracer`` may already be registered by
+        ``autofit.jax.pytrees.register_model`` (its
+        ``_REGISTERED_INSTANCE_CLASSES`` set is independent of autoarray's
+        ``_pytree_registered_classes``); cross-populate so
+        ``register_instance_pytree`` short-circuits. Mirrors the defense in
+        ``autogalaxy/ellipse/model/analysis.py``.
         """
-        from autoarray.abstract_ndarray import register_instance_pytree
+        global _FIT_IMAGING_PYTREES_REGISTERED
+        if _FIT_IMAGING_PYTREES_REGISTERED:
+            return
+
+        from autoarray.abstract_ndarray import (
+            register_instance_pytree,
+            _pytree_registered_classes,
+        )
         from autoarray.dataset.dataset_model import DatasetModel
         from autolens.lens.tracer import Tracer
+
+        try:
+            from autofit.jax.pytrees import (
+                _REGISTERED_INSTANCE_CLASSES as _af_registered,
+            )
+        except ImportError:
+            _af_registered = set()
+
+        for cls in (DatasetModel, Tracer):
+            if cls in _af_registered:
+                _pytree_registered_classes.add(cls)
 
         register_instance_pytree(
             FitImaging,
@@ -186,4 +216,6 @@ class AnalysisImaging(AnalysisDataset):
         register_instance_pytree(DatasetModel)
         # ``cosmology`` is a fixed physical constant per fit; ride as aux.
         register_instance_pytree(Tracer, no_flatten=("cosmology",))
+
+        _FIT_IMAGING_PYTREES_REGISTERED = True
 

--- a/autolens/interferometer/model/analysis.py
+++ b/autolens/interferometer/model/analysis.py
@@ -33,6 +33,9 @@ logger = logging.getLogger(__name__)
 logger.setLevel(level="INFO")
 
 
+_FIT_INTERFEROMETER_PYTREES_REGISTERED = False
+
+
 class AnalysisInterferometer(AnalysisDataset):
     Result = ResultInterferometer
     Visualizer = VisualizerInterferometer
@@ -203,10 +206,33 @@ class AnalysisInterferometer(AnalysisDataset):
         analysis — ride as aux so JAX does not recurse into them. Everything
         else (``tracer`` and the autoarray wrappers it carries) is dynamic
         per fit.
+
+        Idempotent — guarded by the module-level
+        ``_FIT_INTERFEROMETER_PYTREES_REGISTERED`` flag. See
+        ``autolens/imaging/model/analysis.py`` for the cross-registration
+        rationale.
         """
-        from autoarray.abstract_ndarray import register_instance_pytree
+        global _FIT_INTERFEROMETER_PYTREES_REGISTERED
+        if _FIT_INTERFEROMETER_PYTREES_REGISTERED:
+            return
+
+        from autoarray.abstract_ndarray import (
+            register_instance_pytree,
+            _pytree_registered_classes,
+        )
         from autoarray.dataset.dataset_model import DatasetModel  # fit-interferometer-pytree-mge
         from autolens.lens.tracer import Tracer
+
+        try:
+            from autofit.jax.pytrees import (
+                _REGISTERED_INSTANCE_CLASSES as _af_registered,
+            )
+        except ImportError:
+            _af_registered = set()
+
+        for cls in (DatasetModel, Tracer):
+            if cls in _af_registered:
+                _pytree_registered_classes.add(cls)
 
         register_instance_pytree(
             FitInterferometer,
@@ -214,6 +240,8 @@ class AnalysisInterferometer(AnalysisDataset):
         )
         register_instance_pytree(Tracer, no_flatten=("cosmology",))
         register_instance_pytree(DatasetModel)  # fit-interferometer-pytree-mge
+
+        _FIT_INTERFEROMETER_PYTREES_REGISTERED = True
 
     def save_attributes(self, paths: af.DirectoryPaths):
         """


### PR DESCRIPTION
## Summary

Same defensive pattern as the PyAutoGalaxy companion PR — additionally cross-populates \`Tracer\` from autofit's \`_REGISTERED_INSTANCE_CLASSES\` since lens models always carry one, making \`Tracer\` a regular source of duplicate-registration whenever both the autofit walker and the analysis registration path run.

## Repro

Same root cause as autogalaxy companion (multi/start_here.py in autogalaxy_workspace during the 2026.5.29.2 release):

\`\`\`
ValueError: Duplicate custom PyTreeDef type registration for
<class 'autoarray.dataset.dataset_model.DatasetModel'>.
\`\`\`

The autolens analyses register the same class set plus \`Tracer\`. Once \`autofit.jax.pytrees.register_model\` walks a lens model, both \`DatasetModel\` and \`Tracer\` get registered via autofit's path — neither set lands in autoarray's \`_pytree_registered_classes\`, so the next \`fit_from\` call's registration step asks JAX to register them again.

## Fix

For both \`imaging/model/analysis.py\` and \`interferometer/model/analysis.py\`:

1. Module-level \`_FIT_*_PYTREES_REGISTERED = False\` flag.
2. Cross-populate \`(DatasetModel, Tracer)\` from autofit's set into autoarray's.
3. Set the flag at the end.

## Paired with

- PyAutoGalaxy companion PR (same fix)
- PyAutoBuild PR (release.yml \`run_scripts\` env block)

## Test plan

- [x] \`pytest test_autolens/imaging/model test_autolens/interferometer/model\` — passed (unit tests don't exercise JAX path)
- [ ] CI on this PR
- [ ] Next \`autobuild pre_build\` dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)