### PR TITLE
docs: add signpost llms.txt + consolidate agent instructions into AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,27 +1,9 @@
 # Copilot Coding Agent Instructions
 
-You are working on **PyAutoLens**, a Python library for strong gravitational lens modeling built on PyAutoGalaxy.
+You are working on **PyAutoLens**, a Python library for strong gravitational lens
+modeling built on PyAutoGalaxy.
 
-## Key Rules
-
-- Run tests after every change: `python -m pytest test_autolens/`
-- Format code with `black autolens/`
-- All files must use Unix line endings (LF, `\n`)
-- Decorated functions (`@to_array`, `@to_grid`, `@to_vector_yx`) must return **raw arrays**, not autoarray wrappers
-- The `xp` parameter controls NumPy (`xp=np`) vs JAX (`xp=jnp`) — never import JAX at module level
-- Functions called inside `jax.jit` must guard autoarray wrapping with `if xp is np:`
-- If changing public API, clearly document what changed in your PR description — downstream workspaces depend on this
-
-## Architecture
-
-- `autolens/lens/` — `Tracer`, multi-plane ray-tracing, deflection logic
-- `autolens/imaging/`, `interferometer/`, `point/` — Dataset-specific fit and analysis classes
-- `autolens/plot/` — Visualisation for all data types
-- `autolens/aggregator/` — Results scraping
-- `test_autolens/` — Test suite
-
-## Sandboxed runs
-
-```bash
-NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest test_autolens/
-```
+The canonical, agent-agnostic instructions for this repo live in **`AGENTS.md`** at
+the repository root — build and test commands, architecture, the JAX / `xp` backend
+pattern, and the decorator conventions. Read it directly (Copilot does not process
+`@`-imports) and treat it as the single source of truth.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,20 @@
+# PyAutoLens
+
+> PyAutoLens (package `autolens`) is the open-source strong gravitational-lensing modelling library, built on PyAutoGalaxy and using JAX to accelerate lens modelling on GPUs. This file is a signpost: it points you to the right ecosystem resource depending on your intent — use the API, learn lensing, or work on the library itself.
+
+## Use it (examples & tutorials)
+
+- [autolens_workspace navigator](https://github.com/PyAutoLabs/autolens_workspace/blob/main/llms.txt): end-to-end example scripts and notebooks per science case — the paste-friendly task router. Send any "how do I model / simulate / analyse X?" question here.
+- [HowToLens](https://github.com/PyAutoLabs/HowToLens): from-first-principles lecture series for beginners new to gravitational lensing.
+
+## API reference & docs
+
+- [PyAutoLens documentation (ReadTheDocs)](https://pyautolens.readthedocs.io/en/latest/): API reference, feature overviews, and the installation guide.
+
+## Work on PyAutoLens itself (contributors / coding agents)
+
+- [AGENTS.md](./AGENTS.md): build, tests, architecture, and the JAX / decorator conventions.
+
+## Ecosystem (libraries this builds on)
+
+- [PyAutoGalaxy](https://github.com/PyAutoLabs/PyAutoGalaxy), [PyAutoArray](https://github.com/PyAutoLabs/PyAutoArray), [PyAutoFit](https://github.com/PyAutoLabs/PyAutoFit), [PyAutoConf](https://github.com/PyAutoLabs/PyAutoConf): the upstream layers PyAutoLens is built on.


### PR DESCRIPTION
## Summary

Adds a thin **signpost `llms.txt`** at the repo root and consolidates the remaining duplicated agent instructions into the canonical `AGENTS.md`.

### `llms.txt` (new, 20 lines)
A front-door file following the llms.txt convention (one H1, a blockquote summary, then sections of one-line links). It only **points** — no source-tree catalogue, no duplication of `AGENTS.md` or the docs — routing an LLM by intent:
- **Use it** → autolens_workspace navigator (`llms.txt`) + HowToLens
- **API & docs** → ReadTheDocs
- **Work on the library** → `AGENTS.md`
- **Ecosystem** → PyAutoGalaxy / PyAutoArray / PyAutoFit / PyAutoConf

All links verified live (PyAutoLabs org remotes; workspace `llms.txt` present on `origin/main`; ReadTheDocs URL confirmed from the README + `.readthedocs.yaml`).

### `.github/copilot-instructions.md` (consolidated)
Replaced the duplicated Key Rules / Architecture / sandbox blocks with a thin pointer to `AGENTS.md` (the single source of truth, matching `CLAUDE.md` which already `@`-imports it). Also drops the slightly stale `@to_array`/`@to_grid`/`@to_vector_yx` decorator names in favour of `AGENTS.md`'s accurate `aa.decorators.*` guidance.

## Scripts Changed
None — docs only.

## API Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)