### PR TITLE
test: skip jax-backed unit tests when jax is absent (Python matrix)

### DIFF
--- a/test_autolens/interferometer/model/test_analysis_interferometer.py
+++ b/test_autolens/interferometer/model/test_analysis_interferometer.py
@@ -1,3 +1,4 @@
+import importlib.util
 from pathlib import Path
 import pytest
 
@@ -5,6 +6,15 @@ import autofit as af
 import autoarray as aa
 import autolens as al
 from autolens import exc
+
+# The interferometer shared-state preload builds the jax-backed NUFFT sparse
+# operator, so these tests need jax installed to run (it ships via the
+# `[optional]` extras). The NumPy-only Python-version matrix has no jax, so skip
+# there rather than fail.
+requires_jax = pytest.mark.skipif(
+    importlib.util.find_spec("jax") is None,
+    reason="requires jax (installed via the [optional] extras; absent on the NumPy-only matrix env)",
+)
 
 from autolens.interferometer.model.result import ResultInterferometer
 
@@ -87,6 +97,7 @@ def _pixelization_model():
     )
 
 
+@requires_jax
 def test__shared_state_from__preloads_curvature_reused__figure_of_merit_unchanged(
     interferometer_7,
 ):
@@ -121,6 +132,7 @@ def test__shared_state_from__preloads_curvature_reused__figure_of_merit_unchange
     ) == pytest.approx(analysis.log_likelihood_function(instance=instance))
 
 
+@requires_jax
 def test__shared_state_from__returns_none_when_not_opted_in(interferometer_7):
     dataset = interferometer_7.apply_sparse_operator(use_jax=False)
 
@@ -159,6 +171,7 @@ def test__preloads_scoped__cross_type_preloads_reduced_to_mesh_view(interferomet
     assert fit._preloads_scoped is same_type
 
 
+@requires_jax
 def test__shared_state_from__populates_mesh_geometry_fields(interferometer_7):
     dataset = interferometer_7.apply_sparse_operator(use_jax=False)
 

--- a/test_autolens/lens/test_substructure_util.py
+++ b/test_autolens/lens/test_substructure_util.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 import numpy as np
 import pytest
 
@@ -10,6 +12,14 @@ requires_kaplinghat = pytest.mark.skipif(
     reason="Kaplinghat SIDM profiles are provided by the pending PyAutoGalaxy release.",
 )
 
+# `galaxies_to_halo_arrays` is jax-backed; these tests need jax installed to run
+# (it ships via the `[optional]` extras). The NumPy-only Python-version matrix
+# has no jax, so skip there rather than fail.
+requires_jax = pytest.mark.skipif(
+    importlib.util.find_spec("jax") is None,
+    reason="requires jax (installed via the [optional] extras; absent on the NumPy-only matrix env)",
+)
+
 
 @requires_kaplinghat
 def test__autolens_exposes_kaplinghat_profiles_from_autogalaxy():
@@ -17,6 +27,7 @@ def test__autolens_exposes_kaplinghat_profiles_from_autogalaxy():
     assert hasattr(al.mp, "KaplinghatCoredNFWMCRLudlowSph")
 
 
+@requires_jax
 @requires_kaplinghat
 def test__galaxies_to_halo_arrays__packs_kaplinghat_profile_parameters():
     profile = al.mp.KaplinghatCoredNFWSph(
@@ -59,6 +70,7 @@ def test__galaxies_to_halo_arrays__packs_kaplinghat_profile_parameters():
     )
 
 
+@requires_jax
 def test__galaxies_to_halo_arrays__raises_for_unsupported_profile_class():
     with pytest.raises(ValueError):
         substructure_util.galaxies_to_halo_arrays(


### PR DESCRIPTION
## Summary

Part of getting the PyAutoBuild **Python Version Matrix** green. A set of unit tests exercise **jax-only code paths** (vmapped profiles, blackjax NUTS, the NUFFT sparse operator, `use_jax=True`) that need jax installed to run. jax ships via the `[optional]` extras and is present in the per-repo CI (3.12/3.13), so these pass there — but the Python Version Matrix installs the NumPy-only stack (and jax cannot install on 3.9 at all), so they failed with `ModuleNotFoundError: No module named 'jax'`.

Guards the affected tests with `pytest.mark.skipif(importlib.util.find_spec("jax") is None, ...)`. NumPy-only tests in the same files are untouched. Aligns with the repo doctrine "unit tests are NumPy-only; JAX validated in workspace_test".

## Verification
- **jax absent** (clean 2026.7.9.1 venv, no `[optional]`): guarded tests **skip**, all other tests pass.
- **jax present** (dev env): all files collect cleanly, nothing skipped.

Paired across PyAutoArray / PyAutoFit / PyAutoGalaxy / PyAutoLens (`feature/matrix-jax-skip`); test-only, no library source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)