### PR TITLE
docs: fix stale autosummary entries breaking the docs build

### DIFF
--- a/docs/api/mass.rst
+++ b/docs/api/mass.rst
@@ -24,8 +24,8 @@ Total [ag.mp]
    IsothermalSph
    dPIEMass
    dPIEMassSph
-   dPIEMassLenstool
-   dPIEMassLenstoolSph
+   dPIEMassB0
+   dPIEMassB0Sph
    PIEMass
    dPIEPotential
    dPIEPotentialSph

--- a/docs/api/potential_correction.rst
+++ b/docs/api/potential_correction.rst
@@ -13,7 +13,7 @@ functionality in your research, please cite Cao et al. 2025; citation
 materials are provided at
 https://github.com/caoxiaoyue/potential_correction_paper.
 
-.. currentmodule:: autolens.pc
+.. currentmodule:: autolens.potential_correction
 
 .. autosummary::
    :toctree: _autosummary


### PR DESCRIPTION
## What

Fix two stale Sphinx `autosummary` entries that have kept the docs build red on `main` since the `potential_correction` feature landed (2026-07-17):

- **`docs/api/potential_correction.rst`** used `.. currentmodule:: autolens.pc`. `pc` is only an attribute alias (`from . import potential_correction as pc` in `autolens/__init__.py`), not a real module path — Sphinx autosummary can't import it, so every class failed (`No module named 'pc'`). Pointed `currentmodule` at the real module, **`autolens.potential_correction`** (all 15 listed classes are exported there).
- **`docs/api/mass.rst`** listed `dPIEMassLenstool` / `dPIEMassLenstoolSph`, which were renamed to **`dPIEMassB0`** / **`dPIEMassB0Sph`** in `autogalaxy.profiles.mass`.

## Why

The `docs-build` gate fails when the Sphinx warning count exceeds the baseline (`docs/sphinx_warning_baseline.txt`). Each failed autosummary import emits a multi-line traceback into the warning log; these renamed/aliased entries pushed the count over baseline. Both symbols now import cleanly, removing those warnings.

## Validation

Verified against the installed source that every class listed in `potential_correction.rst` is exported from `autolens.potential_correction`, and that `dPIEMassB0` / `dPIEMassB0Sph` are exported from `autogalaxy.profiles.mass`. Docs `docs-build` CI on this PR is the check to confirm the warning count is back under baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_