### PR TITLE
refactor!: depend on and import `autonerves` (renamed from autoconf)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ point-source datasets.
 
 Dependency direction: autolens sits at the top of the stack and may import all
 four layers below it — **autogalaxy**, **autoarray**, **autofit**, and
-**autoconf**. Nothing in the ecosystem imports autolens.
+**autonerves**. Nothing in the ecosystem imports autolens.
 
 ## Related repos
 
@@ -51,7 +51,7 @@ is no black/ruff/flake8 gate — formatting is advisory. (`requires-python` in
 
 ## Configuration & defaults
 
-autoconf supplies the packaged defaults under `autolens/config/`. Workspaces
+autonerves supplies the packaged defaults under `autolens/config/`. Workspaces
 override them via their own `config/` directory; the test suite pushes a local
 config dir via `conf.instance.push(...)` in `test_autolens/conftest.py`. When a
 change adds a new config key, mirror it into the packaged defaults so

--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -1,5 +1,5 @@
-from autoconf import jax_wrapper
-from autoconf.dictable import from_dict, from_json, output_to_json, to_dict
+from autonerves import jax_wrapper
+from autonerves.dictable import from_dict, from_json, output_to_json, to_dict
 from autoarray import preprocess
 
 from autoarray.dataset.imaging.dataset import Imaging
@@ -135,18 +135,18 @@ from . import mock as m
 from . import util
 from . import potential_correction as pc
 
-from autoconf import conf
-from autoconf.fitsable import ndarray_via_hdu_from
-from autoconf.fitsable import ndarray_via_fits_from
-from autoconf.fitsable import header_obj_from
-from autoconf.fitsable import output_to_fits
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves import conf
+from autonerves.fitsable import ndarray_via_hdu_from
+from autonerves.fitsable import ndarray_via_fits_from
+from autonerves.fitsable import header_obj_from
+from autonerves.fitsable import output_to_fits
+from autonerves.fitsable import hdu_list_for_output_from
 
 conf.instance.register(__file__)
 
 __version__ = "2026.7.9.1"
 
-from autoconf import check_version
+from autonerves import check_version
 
 check_version(__version__)
 
@@ -166,28 +166,28 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 # ---------------------------------------------------------------------------
-# Public re-export of the autoconf configuration / serialization surface.
+# Public re-export of the autonerves configuration / serialization surface.
 #
 # Workspaces, tutorials and downstream code import these names from the science
 # library (e.g. ``from autolens import conf``) rather than depending on the
-# ``autoconf`` package directly, so the underlying configuration / serialization
+# ``autonerves`` package directly, so the underlying configuration / serialization
 # layer stays an implementation detail of the library.
 # ---------------------------------------------------------------------------
-from autoconf import conf
-from autoconf import jax_wrapper
-from autoconf import fitsable
-from autoconf import setup_colab
-from autoconf import setup_notebook
-from autoconf.conf import with_config
-from autoconf.dictable import from_dict, from_json, to_dict, output_to_json
-from autoconf.fitsable import (
+from autonerves import conf
+from autonerves import jax_wrapper
+from autonerves import fitsable
+from autonerves import setup_colab
+from autonerves import setup_notebook
+from autonerves.conf import with_config
+from autonerves.dictable import from_dict, from_json, to_dict, output_to_json
+from autonerves.fitsable import (
     output_to_fits,
     hdu_list_for_output_from,
     ndarray_via_fits_from,
     ndarray_via_hdu_from,
     header_obj_from,
 )
-from autoconf.test_mode import (
+from autonerves.test_mode import (
     with_test_mode_segment,
     skip_visualization,
     skip_fit_output,

--- a/autolens/analysis/analysis/dataset.py
+++ b/autolens/analysis/analysis/dataset.py
@@ -17,8 +17,8 @@ import numpy as np
 import os
 from typing import List, Optional
 
-from autoconf import conf
-from autoconf.dictable import output_to_json
+from autonerves import conf
+from autonerves.dictable import output_to_json
 
 import autofit as af
 import autoarray as aa
@@ -31,7 +31,7 @@ from autolens.analysis.result import ResultDataset
 from autolens.analysis.positions import PositionsLH
 
 from autolens import exc
-from autoconf.test_mode import skip_checks
+from autonerves.test_mode import skip_checks
 
 logger = logging.getLogger(__name__)
 

--- a/autolens/analysis/latent.py
+++ b/autolens/analysis/latent.py
@@ -24,7 +24,7 @@ from typing import Callable, Dict, List, Optional
 import numpy as np
 
 import autofit as af
-from autoconf import conf
+from autonerves import conf
 from autogalaxy.imaging.model.latent import (
     ab_mag_via_flux_from,
     flux_mujy_via_ab_mag_from,

--- a/autolens/analysis/result.py
+++ b/autolens/analysis/result.py
@@ -32,7 +32,7 @@ from autolens.point.max_separation import (
 )
 from autolens.lens.tracer import Tracer
 from autolens.point.solver import PointSolver
-from autoconf.test_mode import is_test_mode, skip_checks
+from autonerves.test_mode import is_test_mode, skip_checks
 
 logger = logging.getLogger(__name__)
 

--- a/autolens/config/latent.yaml
+++ b/autolens/config/latent.yaml
@@ -15,7 +15,7 @@
 # `false` and return NaN + one warning per process if enabled without
 # `magzero` (rather than raising, which would discard a converged search).
 #
-# autoconf lowercases yaml keys at read time, so the registry/yaml names
+# autonerves lowercases yaml keys at read time, so the registry/yaml names
 # must be snake_case-lowercase (this leaks into the `latent.csv` column
 # header — e.g. `total_lens_flux_mujy`, not `_muJy`).
 

--- a/autolens/imaging/fit_imaging.py
+++ b/autolens/imaging/fit_imaging.py
@@ -23,7 +23,7 @@ import functools
 import numpy as np
 from typing import Dict, List, Optional
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 import autoarray as aa
 import autogalaxy as ag

--- a/autolens/imaging/model/analysis.py
+++ b/autolens/imaging/model/analysis.py
@@ -18,7 +18,7 @@ import autoarray as aa
 import autofit as af
 import autogalaxy as ag
 
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.fitsable import hdu_list_for_output_from
 
 from autolens.analysis.analysis.dataset import AnalysisDataset
 from autolens.analysis.latent import LatentLens

--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -18,7 +18,7 @@ The ``TracerToInversion`` helper is used to assemble the linear system in step 4
 import numpy as np
 from typing import Dict, List, Optional
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 import autoarray as aa
 import autogalaxy as ag

--- a/autolens/interferometer/model/analysis.py
+++ b/autolens/interferometer/model/analysis.py
@@ -16,8 +16,8 @@ import logging
 import numpy as np
 from typing import Optional
 
-from autoconf.dictable import to_dict
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.dictable import to_dict
+from autonerves.fitsable import hdu_list_for_output_from
 
 import autofit as af
 import autoarray as aa

--- a/autolens/lens/los.py
+++ b/autolens/lens/los.py
@@ -22,7 +22,7 @@ from typing import List, Optional, Tuple
 import autogalaxy as ag
 from autogalaxy.cosmology import Planck15
 
-from autoconf.test_mode import is_test_mode
+from autonerves.test_mode import is_test_mode
 
 # Number of LOS halos retained per plane when ``PYAUTO_TEST_MODE`` is active.
 # Capping the population keeps the multi-plane ray-tracing and per-galaxy

--- a/autolens/lens/plot/tracer_plots.py
+++ b/autolens/lens/plot/tracer_plots.py
@@ -53,7 +53,7 @@ def plane_image_from(
     aa.Array2D
         Plane image on the (possibly zoomed) grid.
     """
-    from autoconf import conf
+    from autonerves import conf
 
     shape = grid.shape_native
 
@@ -389,7 +389,7 @@ def fits_tracer(
         Directory in which to write ``tracer.fits``.
     """
     from pathlib import Path
-    from autoconf.fitsable import hdu_list_for_output_from
+    from autonerves.fitsable import hdu_list_for_output_from
 
     output_path = Path(output_path)
     zoom = aa.Zoom2D(mask=grid.mask)
@@ -439,8 +439,8 @@ def fits_source_plane_images(
     """
     import ast
     from pathlib import Path
-    from autoconf import conf
-    from autoconf.fitsable import hdu_list_for_output_from
+    from autonerves import conf
+    from autonerves.fitsable import hdu_list_for_output_from
 
     output_path = Path(output_path)
     shape_native = tuple(ast.literal_eval(

--- a/autolens/lens/to_inversion.py
+++ b/autolens/lens/to_inversion.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 import autoarray as aa
 import autogalaxy as ag

--- a/autolens/point/dataset.py
+++ b/autolens/point/dataset.py
@@ -15,14 +15,14 @@ background sources in a strong-lens cluster) they are collected in a plain Pytho
 
 Two I/O surfaces are supported:
 
-- JSON (via :func:`autoconf.output_to_json` / :func:`autoconf.from_json`) — exact
+- JSON (via :func:`autonerves.output_to_json` / :func:`autonerves.from_json`) — exact
   round-trip, one file per ``PointDataset``; the canonical modeling input.
 - CSV (via :meth:`PointDataset.to_csv` / :meth:`PointDataset.from_csv` and the
   module-level :func:`output_to_csv` / :func:`list_from_csv`) — one row per observed
   image, grouped by ``name``, so that tens or hundreds of cluster-scale point sources
   can be edited in a single spreadsheet.
 """
-from autoconf import csvable
+from autonerves import csvable
 from typing import List, Tuple, Optional, Union
 
 import autoarray as aa

--- a/docs/general/configs.md
+++ b/docs/general/configs.md
@@ -15,7 +15,7 @@ The configuration path can also be set manually in a script using the project **
 command (the path to the `output` folder where the results of a non-linear search are stored is also set below):
 
 ```bash
-from autoconf import conf
+from autonerves import conf
 
 conf.instance.push(
     config_path="path/to/config",

--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -48,7 +48,7 @@ git clone https://github.com/PyAutoLabs/PyAutoLens
 Next, install the **PyAuto** parent projects via pip:
 
 ```bash
-pip install autoconf
+pip install autonerves
 pip install autofit
 pip install autoarray
 pip install autogalaxy
@@ -114,7 +114,7 @@ git clone https://github.com/PyAutoLabs/PyAutoLens
 Next, install **PyAutoConf** via pip:
 
 ```bash
-pip install autoconf
+pip install autonerves
 ```
 
 Next, install the source build dependencies of each project via pip:

--- a/patches/autoarray/0001-PR-A1-Add-autoarray-plot-plots-direct-matplotlib-mod.patch
+++ b/patches/autoarray/0001-PR-A1-Add-autoarray-plot-plots-direct-matplotlib-mod.patch
@@ -193,7 +193,7 @@ index 00000000..20f5f267
 +
 +    # --- colour normalisation --------------------------------------------------
 +    if use_log10:
-+        from autoconf import conf as _conf
++        from autonerves import conf as _conf
 +
 +        try:
 +            log10_min = _conf.instance["visualize"]["general"]["general"][
@@ -649,7 +649,7 @@ index 00000000..4d1cc4f0
 +        Either ``"figures"`` (single-panel) or ``"subplots"`` (multi-panel).
 +    """
 +    try:
-+        from autoconf import conf
++        from autonerves import conf
 +
 +        return tuple(conf.instance["visualize"]["general"][context]["figsize"])
 +    except Exception:

--- a/test_autolens/analysis/analysis/test_analysis_dataset.py
+++ b/test_autolens/analysis/analysis/test_analysis_dataset.py
@@ -2,8 +2,8 @@ from pathlib import Path
 import os
 import pytest
 
-from autoconf import conf
-from autoconf.dictable import from_json
+from autonerves import conf
+from autonerves.dictable import from_json
 
 import autofit as af
 import autolens as al

--- a/test_autolens/analysis/test_analysis.py
+++ b/test_autolens/analysis/test_analysis.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import os
 import pytest
 
-from autoconf import conf
-from autoconf.dictable import from_json
+from autonerves import conf
+from autonerves.dictable import from_json
 
 import autofit as af
 import autolens as al

--- a/test_autolens/analysis/test_positions.py
+++ b/test_autolens/analysis/test_positions.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 import pytest
 
-from autoconf.dictable import output_to_json, from_json, from_dict
+from autonerves.dictable import output_to_json, from_json, from_dict
 from autofit.tools.util import open_
 
 import autolens as al

--- a/test_autolens/lens/test_tracer.py
+++ b/test_autolens/lens/test_tracer.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from pathlib import Path
 
-from autoconf.dictable import from_json, output_to_json
+from autonerves.dictable import from_json, output_to_json
 import autofit as af
 import autolens as al
 

--- a/test_autolens/point/triangles/test_regressions.py
+++ b/test_autolens/point/triangles/test_regressions.py
@@ -1,4 +1,4 @@
-from autoconf.dictable import from_dict
+from autonerves.dictable import from_dict
 import autolens as al
 from autolens.point.solver import PointSolver
 

--- a/test_autolens/test_config.py
+++ b/test_autolens/test_config.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from autoconf import conf
+from autonerves import conf
 
 directory = Path(__file__).resolve().parent
 


### PR DESCRIPTION
## What

Switch the `autoconf` dependency to its renamed form **`autonerves`**: pyproject pins and every `import autoconf` / `from autoconf` (including the config re-export block). Repo-name references (`PyAutoConf`) are unchanged — they flip with the GitHub repo rename.

⚠️ **Breaking / coordinated**: pairs with PyAutoConf#135 and the other library PRs on the **same-named branch**. CI resolves `autonerves` from the same-named PyAutoConf branch. Merge together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_