### PR TITLE
docs: make software citations exhaustive vs current requirements

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -11,7 +11,7 @@ entry in the above .bib file is under the citation key `pyautolens`. Please also
 papers (<https://academic.oup.com/mnras/article/452/3/2940/1749640> and <https://academic.oup.com/mnras/article-abstract/478/4/4738/5001434?redirectedFrom=fulltext>) which are included
 under the citation keys `Nightingale2015` and `Nightingale2018`.
 
-You should also specify the non-linear search(es) you use in your analysis (e.g. Dynesty, Emcee, PySwarms, etc) in
+You should also specify the non-linear search(es) you use in your analysis (e.g. Nautilus, Dynesty, Emcee, Zeus, etc) in
 the main body of text, and delete as appropriate any packages your analysis did not use. The citations.bib file includes
 the citation key for all of these projects.
 

--- a/docs/general/citations.md
+++ b/docs/general/citations.md
@@ -13,9 +13,20 @@ entry in the above .bib file is under the citation key `pyautolens`. Please also
 papers (<https://academic.oup.com/mnras/article/452/3/2940/1749640> and <https://academic.oup.com/mnras/article-abstract/478/4/4738/5001434?redirectedFrom=fulltext>) which are included
 under the citation keys `Nightingale2015` and `Nightingale2018`.
 
-You should also specify the non-linear search(es) you use in your analysis (e.g. Dynesty, Emcee, PySwarms, etc) in
+You should also specify the non-linear search(es) you use in your analysis (e.g. Nautilus, Dynesty, Emcee, Zeus, etc) in
 the main body of text, and delete as appropriate any packages your analysis did not use. The citations.bib file includes
 the citation key for all of these projects.
+
+## JAX
+
+**PyAutoLens** runs on a NumPy backend by default and an optional
+[JAX](https://github.com/jax-ml/jax) backend for just-in-time compilation, automatic
+differentiation, and GPU/TPU execution. If you run any analysis on the JAX path, please
+cite JAX under the citation key `jax`. JAX-specific components that are also cited under
+their own keys when used are `optax` (gradient-based optimizers, key `optax`), the
+interferometer non-uniform FFT (`nufftax` and its FINUFFT algorithm, keys `nufftax` and
+`finufft`, see below), and the critical-curve/caustic solver (`Jax-Zero-Contour`, key
+`jax_zero_contour`, see below).
 
 ## Jax-Zero-Contour
 

--- a/files/citations.bib
+++ b/files/citations.bib
@@ -203,16 +203,6 @@ title = {{Python non-uniform fast fourier transform (PyNUFFT): An accelerated no
 volume = {4},
 year = {2018}
 }
-@article{pyswarms,
-    author  = {Lester James V. Miranda},
-    title   = "{P}y{S}warms, a research-toolkit for {P}article {S}warm {O}ptimization in {P}ython",
-    journal = {J. Open Source Softw.},
-    year    = {2018},
-    volume  = {3},
-    issue   = {21},
-    doi     = {10.21105/joss.00433},
-    url     = {https://doi.org/10.21105/joss.00433}
-}
  @book{python,
  author = {Van Rossum, Guido and Drake, Fred L.},
  title = {Python 3 Reference Manual},
@@ -270,24 +260,6 @@ year = {2018}
   version={3.31.1},
   year={2020},
   author={Hipp, Richard D}
-}
-@ARTICLE{ultranest,
-       author = {{Buchner}, Johannes},
-        title = "{UltraNest - a robust, general purpose Bayesian inference engine}",
-      journal = {The J. Open Source Softw.},
-     keywords = {C, Monte Carlo, Python, Nested Sampling, C++, Bayesian inference, Fortran, Bayes factors, Statistics - Computation, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2021,
-        month = apr,
-       volume = {6},
-       number = {60},
-          eid = {3001},
-        pages = {3001},
-          doi = {10.21105/joss.03001},
-archivePrefix = {arXiv},
-       eprint = {2101.09604},
- primaryClass = {stat.CO},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2021JOSS....6.3001B},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 @article{zeus1,
     title={zeus: A Python Implementation of the Ensemble Slice Sampling method},
@@ -373,61 +345,9 @@ year = {2019}
     eprint = {https://academic.oup.com/mnras/article-pdf/488/1/1387/28937972/stz1796.pdf},
 }
 
-@INPROCEEDINGS{multinest1,
-       author = {{Skilling}, John},
-        title = "{Nested Sampling}",
-     keywords = {02.50.Tt, Inference methods},
-    booktitle = {Bayesian Inference and Maximum Entropy Methods in Science and Engineering: 24th International Workshop on Bayesian Inference and Maximum Entropy Methods in Science and Engineering},
-         year = 2004,
-       editor = {{Fischer}, Rainer and {Preuss}, Roland and {Toussaint}, Udo Von},
-       series = {American Institute of Physics Conference Series},
-       volume = {735},
-        month = nov,
-        pages = {395-405},
-          doi = {10.1063/1.1835238},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2004AIPC..735..395S},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
 
 
-@article{multinest2,
-abstract = {Nested sampling estimates directly how the likelihood function relates to prior mass. The evidence (alternatively the marginal likelihood, marginal density of the data, or the prior predictive) is immediately obtained by summation. It is the prime result of the computation, and is accompanied by an estimate of numerical uncertainty. Samples from the posterior distribution are an optional by-product, obtainable for any temperature. The method relies on sampling within a hard constraint on likelihood value, as opposed to the softened likelihood of annealing methods. Progress depends only on the shape of the "nested"contours of likelihood, and not on the likelihood values. This invariance (over monotonic relabelling) allows the method to deal with a class of phasechange problems which effectively defeat thermal annealing. {\textcopyright} 2006 International Society for Bayesian Analysis.},
-archivePrefix = {arXiv},
-arxivId = {arXiv:1011.1669v3},
-author = {Skilling, John},
-doi = {10.1214/06-BA127},
-eprint = {arXiv:1011.1669v3},
-isbn = {9788578110796},
-issn = {19360975},
-journal = {Bayesian Analysis},
-keywords = {Algorithm,Annealing,Bayesian computation,Evidence,Marginal likelihood,Model selection,Nest,Phase change},
-number = {4},
-pages = {833--860},
-pmid = {25246403},
-title = {{Nested sampling for general Bayesian computation}},
-url = {http://projecteuclid.org/euclid.ba/1340370944},
-volume = {1},
-year = {2006}
-}
 
-@article{multinest3,
-abstract = {We present further development and the first public release of our multimodal nested sampling algorithm, called MultiNest. This Bayesian inference tool calculates the evidence, with an associated error estimate, and produces posterior samples from distributions that may contain multiple modes and pronounced (curving) degeneracies in high dimensions. The developments presented here lead to further substantial improvements in sampling efficiency and robustness, as compared to the original algorithm presented in Feroz and Hobson, which itself significantly outperformed existing Markov chain Monte Carlo techniques in a wide range of astrophysical inference problems. The accuracy and economy of the MultiNest algorithm are demonstrated by application to two toy problems and to a cosmological inference problem focusing on the extension of the vanilla $\Lambda$ cold dark matter model to include spatial curvature and a varying equation of state for dark energy. The MultiNest software, which is fully parallelized using MPI and includes an interface to CosmoMC, is available at http://www.mrao.cam.ac.uk/software/multinest/. It will also be released as part of the SuperBayeS package, for the analysis of supersymmetric theories of particle physics, at http://www.superbayes.org. {\textcopyright} 2009 RAS.},
-archivePrefix = {arXiv},
-arxivId = {0809.3437},
-author = {Feroz, F. and Hobson, M. P. and Bridges, M.},
-doi = {10.1111/j.1365-2966.2009.14548.x},
-eprint = {0809.3437},
-isbn = {0035-8711},
-issn = {00358711},
-journal = {MNRAS},
-keywords = {Methods: Data analysis,Methods: Statistical},
-number = {4},
-pages = {1601--1614},
-pmid = {29176},
-title = {{MultiNest: An efficient and robust Bayesian inference tool for cosmology and particle physics}},
-volume = {398},
-year = {2009}
-}
 
 @article{dynesty4,
 title={joshspeagle/dynesty: v2.1.2}, DOI={10.5281/zenodo.7995596},
@@ -435,3 +355,102 @@ abstractNote={<p>This is a bug release mostly concerning the checkpointing. Chec
 publisher={Zenodo},
 author={Sergey Koposov and Josh Speagle and Kyle Barbary and Gregory Ashton and Ed Bennett and Johannes Buchner
 and Carl Scheffler and Ben Cook and Colm Talbot and James Guillochon and et al.}, year={2023}, month={Jun} }
+
+@software{jax,
+author = {Bradbury, James and Frostig, Roy and Hawkins, Peter and Johnson, Matthew James and Leary, Chris and Maclaurin, Dougal and Necula, George and Paszke, Adam and VanderPlas, Jake and Wanderman-Milne, Skye and Zhang, Qiao},
+title = {{JAX}: composable transformations of {Python}+{NumPy} programs},
+url = {https://github.com/jax-ml/jax},
+year = {2018}
+}
+
+@software{optax,
+author = {{DeepMind} and Babuschkin, Igor and Baumli, Kate and Bell, Alison and Bhupatiraju, Surya and Bruce, Jake and Buchlovsky, Peter and Budden, David and Cai, Trevor and Clark, Aidan and Danihelka, Ivo and Fantacci, Claudio and Godwin, Jonathan and Jones, Chris and Hemsley, Ross and Hennigan, Tom and Hessel, Matteo and Hou, Shaobo and Kapturowski, Steven and others},
+title = {The {D}eep{M}ind {JAX} Ecosystem},
+url = {http://github.com/google-deepmind},
+year = {2020}
+}
+
+@article{anesthetic,
+author = {Handley, Will},
+title = {anesthetic: nested sampling visualisation},
+journal = {J. Open Source Softw.},
+volume = {4},
+number = {37},
+pages = {1414},
+doi = {10.21105/joss.01414},
+year = {2019}
+}
+
+@article{getdist,
+author = {Lewis, Antony},
+title = {{GetDist}: a {Python} package for analysing {Monte Carlo} samples},
+journal = {arXiv e-prints},
+eprint = {1910.13970},
+archivePrefix = {arXiv},
+year = {2019}
+}
+
+@article{blackjax,
+author = {Cabezas, Alberto and Corenflos, Adrien and Lao, Junpeng and Louf, R{\'e}mi and others},
+title = {{BlackJAX}: Composable {B}ayesian inference in {JAX}},
+journal = {arXiv e-prints},
+eprint = {2402.10797},
+archivePrefix = {arXiv},
+year = {2024}
+}
+
+@article{coolest,
+author = {Galan, A. and Vernardos, G. and Minor, Q. and Sluse, D. and {Van de Vyvere}, L. and Gomer, M.},
+title = {{Exploiting the diversity of modeling methods to probe systematic biases in strong lensing analyses}},
+journal = {A&A},
+volume = {692},
+pages = {A87},
+doi = {10.1051/0004-6361/202451095},
+year = {2024}
+}
+
+@inproceedings{networkx,
+author = {Hagberg, Aric A. and Schult, Daniel A. and Swart, Pieter J.},
+title = {Exploring Network Structure, Dynamics, and Function using {NetworkX}},
+booktitle = {Proceedings of the 7th Python in Science Conference (SciPy2008)},
+editor = {Varoquaux, Ga\"el and Vaught, Travis and Millman, Jarrod},
+pages = {11--15},
+address = {Pasadena, CA USA},
+year = {2008}
+}
+
+@article{tfp,
+author = {Dillon, Joshua V. and Langmore, Ian and Tran, Dustin and Brevdo, Eugene and Vasudevan, Srinivas and Moore, Dave and Patton, Brian and Alemi, Alex and Hoffman, Matthew D. and Saurous, Rif A.},
+title = {{TensorFlow} Distributions},
+journal = {arXiv e-prints},
+eprint = {1711.10604},
+archivePrefix = {arXiv},
+year = {2017}
+}
+
+@software{nufftax,
+author = {Gragas and Oudoumanessah, Geoffroy and Iollo, Jacopo},
+title = {nufftax: Pure {JAX} implementation of the Non-Uniform Fast Fourier Transform},
+url = {https://github.com/GragasLab/nufftax},
+year = {2026}
+}
+
+@article{finufft,
+author = {Barnett, Alexander H. and Magland, Jeremy F. and af Klinteberg, Ludvig},
+title = {A parallel non-uniform fast {F}ourier transform library based on an 'exponential of semicircle' kernel},
+journal = {SIAM J. Sci. Comput.},
+volume = {41},
+number = {5},
+pages = {C479--C504},
+year = {2019}
+}
+
+@software{jax_zero_contour,
+author = {Krawczyk, Coleman},
+title = {{CKrawczyk/Jax-Zero-Contour}: Version 2.0.0},
+publisher = {Zenodo},
+version = {v2.0.0},
+doi = {10.5281/zenodo.15730415},
+url = {https://doi.org/10.5281/zenodo.15730415},
+year = {2025}
+}

--- a/files/citations.md
+++ b/files/citations.md
@@ -2,29 +2,38 @@
 
 We use the lens modeling software `PyAutoLens` https://github.com/PyAutoLabs/PyAutoLens) [@pyautolens] [@Nightingale2015] [@Nightingale2018] to...
 
-**At the end of the paper (delete as appropriate, see https://pyautofit.readthedocs.io/en/latest/general/citations.html):**
+**At the end of the paper (delete as appropriate, see https://pyautolens.readthedocs.io/en/latest/general/citations.html):**
 
 # Software Citations
 
 This work uses the following software packages:
 
+- `anesthetic` https://github.com/handley-lab/anesthetic [@anesthetic]
 - `Astropy` https://github.com/astropy/astropy [@astropy1] [@astropy2]
+- `BlackJAX` https://github.com/blackjax-devs/blackjax [@blackjax]
 - `Colossus` https://bitbucket.org/bdiemer/colossus/src/main/ [@colossus]
+- `COOLEST` https://github.com/aymgal/COOLEST [@coolest]
 - `corner.py` https://github.com/dfm/corner.py [@corner]
-- `dynesty` https://github.com/joshspeagle/dynesty [@dynesty] [@dynesty1] [@dynesty2] [@dynesty3] [@dynesty4]
+- `dynesty` https://github.com/joshspeagle/dynesty [@dynesty] [@dynesty4]
 - `emcee` https://github.com/dfm/emcee [@emcee]
+- `GetDist` https://github.com/cmbant/getdist [@getdist]
+- `JAX` https://github.com/jax-ml/jax [@jax]
+- `Jax-Zero-Contour` https://github.com/CKrawczyk/Jax-Zero-Contour [@jax_zero_contour]
 - `matplotlib` https://github.com/matplotlib/matplotlib [@matplotlib]
+- `nautilus` https://github.com/johannesulf/nautilus [@nautilus]
+- `NetworkX` https://github.com/networkx/networkx [@networkx]
+- `nufftax` https://github.com/GragasLab/nufftax [@nufftax] [@finufft]
 - `numba` https://github.com/numba/numba [@numba]
 - `NumPy` https://github.com/numpy/numpy [@numpy]
+- `optax` https://github.com/google-deepmind/optax [@optax]
 - `PyAutoFit` https://github.com/PyAutoLabs/PyAutoFit [@pyautofit]
 - `PyAutoGalaxy` https://github.com/PyAutoLabs/PyAutoGalaxy [@Nightingale2018] [@pyautogalaxy]
 - `PyAutoLens` https://github.com/PyAutoLabs/PyAutoLens [@Nightingale2015] [@Nightingale2018] [@pyautolens]
 - `PyNUFFT` https://github.com/jyhmiinlin/pynufft [@pynufft]
-- `PySwarms` https://github.com/ljvmiranda921/pyswarms [@pyswarms]
 - `Python` https://www.python.org/ [@python]
 - `scikit-image` https://github.com/scikit-image/scikit-image [@scikit-image]
 - `scikit-learn` https://github.com/scikit-learn/scikit-learn [@scikit-learn]
 - `Scipy` https://github.com/scipy/scipy [@scipy]
 - `SQLite` https://www.sqlite.org/index.html [@sqlite]
-- `UltraNest` https://github.com/JohannesBuchner/UltraNest [@ultranest]
+- `TensorFlow Probability` https://github.com/tensorflow/probability [@tfp]
 - `Zeus` https://github.com/minaskar/zeus [@zeus1] [@zeus2]

--- a/files/citations.tex
+++ b/files/citations.tex
@@ -1,6 +1,6 @@
 **Insert in the main body of the paper:**
 
-We use the lens modeling software \textt{PyAutoLens} \footnote{https://github.com/Jammy2211/PyAutoLens} \citep{pyautolens, Nightingale2015, Nightingale2018} to...
+We use the lens modeling software \texttt{PyAutoLens} \footnote{https://github.com/PyAutoLabs/PyAutoLens} \citep{pyautolens, Nightingale2015, Nightingale2018} to...
 
 **At the end of the paper (delete as appropriate, see https://pyautolens.readthedocs.io/en/latest/general/citations.html):**
 
@@ -11,85 +11,119 @@ This work uses the following software packages:
 \begin{itemize}
 
 \item
-\href{https://github.com/astropy/astropy}{\textt{Astropy}}
+\href{https://github.com/handley-lab/anesthetic}{\texttt{anesthetic}}
+\citep{anesthetic}
+
+\item
+\href{https://github.com/astropy/astropy}{\texttt{Astropy}}
 \citep{astropy1, astropy2}
 
 \item
-\href{https://bitbucket.org/bdiemer/colossus/src/main/}{\textt{Colossus}}
+\href{https://github.com/blackjax-devs/blackjax}{\texttt{BlackJAX}}
+\citep{blackjax}
+
+\item
+\href{https://bitbucket.org/bdiemer/colossus/src/main/}{\texttt{Colossus}}
 \citep{colossus}
 
 \item
-\href{https://github.com/dfm/corner.py}{\textt{corner.py}}
+\href{https://github.com/aymgal/COOLEST}{\texttt{COOLEST}}
+\citep{coolest}
+
+\item
+\href{https://github.com/dfm/corner.py}{\texttt{corner.py}}
 \citep{corner}
 
 \item
-\href{https://github.com/joshspeagle/dynesty}{\textt{dynesty}}
-\citep{dynesty, dynesty1, dynesty2, dynesty3, dynesty4}
+\href{https://github.com/joshspeagle/dynesty}{\texttt{dynesty}}
+\citep{dynesty, dynesty4}
 
 \item
-\href{https://github.com/dfm/emcee}{\textt{emcee}}
+\href{https://github.com/dfm/emcee}{\texttt{emcee}}
 \citep{emcee}
 
 \item
-\href{https://github.com/matplotlib/matplotlib}{\textt{matplotlib}}
+\href{https://github.com/cmbant/getdist}{\texttt{GetDist}}
+\citep{getdist}
+
+\item
+\href{https://github.com/jax-ml/jax}{\texttt{JAX}}
+\citep{jax}
+
+\item
+\href{https://github.com/CKrawczyk/Jax-Zero-Contour}{\texttt{Jax-Zero-Contour}}
+\citep{jax_zero_contour}
+
+\item
+\href{https://github.com/matplotlib/matplotlib}{\texttt{matplotlib}}
 \citep{matplotlib}
 
 \item
-\href{numba` https://github.com/numba/numba}{\textt{numba}}
+\href{https://github.com/johannesulf/nautilus}{\texttt{nautilus}}
+\citep{nautilus}
+
+\item
+\href{https://github.com/networkx/networkx}{\texttt{NetworkX}}
+\citep{networkx}
+
+\item
+\href{https://github.com/GragasLab/nufftax}{\texttt{nufftax}}
+\citep{nufftax, finufft}
+
+\item
+\href{https://github.com/numba/numba}{\texttt{numba}}
 \citep{numba}
 
 \item
-\href{https://github.com/numpy/numpy}{\textt{NumPy}}
+\href{https://github.com/numpy/numpy}{\texttt{NumPy}}
 \citep{numpy}
 
 \item
-\href{https://github.com/rhayes777/PyAutoFit}{\textt{PyAutoFit}}
+\href{https://github.com/google-deepmind/optax}{\texttt{optax}}
+\citep{optax}
+
+\item
+\href{https://github.com/PyAutoLabs/PyAutoFit}{\texttt{PyAutoFit}}
 \citep{pyautofit}
 
 \item
-\href{https://github.com/Jammy2211/PyAutoGalaxy}{\textt{PyAutoGalaxy}}
+\href{https://github.com/PyAutoLabs/PyAutoGalaxy}{\texttt{PyAutoGalaxy}}
 \citep{Nightingale2018, pyautogalaxy}
 
 \item
-\href{https://github.com/Jammy2211/PyAutoLens}{\textt{PyAutoLens}}
+\href{https://github.com/PyAutoLabs/PyAutoLens}{\texttt{PyAutoLens}}
 \citep{Nightingale2015, Nightingale2018, pyautolens}
 
-
 \item
-\href{https://github.com/jyhmiinlin/pynufft}{\textt{PyNUFFT}}
+\href{https://github.com/jyhmiinlin/pynufft}{\texttt{PyNUFFT}}
 \citep{pynufft}
 
 \item
-\href{https://github.com/ljvmiranda921/pyswarms}{\textt{PySwarms}}
-\citep{pyswarms}
-
-\item
-\href{https://www.python.org/}{\textt{Python}}
+\href{https://www.python.org/}{\texttt{Python}}
 \citep{python}
 
 \item
-\href{https://github.com/scikit-image/scikit-image}{\textt{scikit-image}}
+\href{https://github.com/scikit-image/scikit-image}{\texttt{scikit-image}}
 \citep{scikit-image}
 
 \item
-\href{https://github.com/scikit-learn/scikit-learn}{\textt{scikit-learn}}
+\href{https://github.com/scikit-learn/scikit-learn}{\texttt{scikit-learn}}
 \citep{scikit-learn}
 
 \item
-\href{https://github.com/scipy/scipy}{\textt{Scipy}}
+\href{https://github.com/scipy/scipy}{\texttt{Scipy}}
 \citep{scipy}
 
 \item
-\href{https://www.sqlite.org/index.html}
+\href{https://www.sqlite.org/index.html}{\texttt{SQLite}}
 \citep{sqlite}
 
 \item
-\href{https://github.com/JohannesBuchner/UltraNest}{\textt{UltraNest}}
-\citep{ultranest}
+\href{https://github.com/tensorflow/probability}{\texttt{TensorFlow Probability}}
+\citep{tfp}
 
 \item
-\href{https://github.com/minaskar/zeus}{\textt{zeus}}
+\href{https://github.com/minaskar/zeus}{\texttt{zeus}}
 \citep{zeus1, zeus2}
-
 
 \end{itemize}


### PR DESCRIPTION
Cross-referenced every `pyproject.toml` in the stack (autonerves → autoarray → autofit → autogalaxy → autolens) against `files/citations.bib` and brought the citation set up to date with the **current requirements**.

## Added (missing current dependencies)
JAX, optax, anesthetic, getdist, blackjax, coolest, networkx, tensorflow-probability, nufftax + finufft, and jax_zero_contour (the last three consolidated from inline bibtex that already lived in the docs page). Each verified against its published reference / software release. Added a **JAX** section to `docs/general/citations.md`.

## Removed (no longer requirements)
MultiNest, UltraNest, PySwarms — pruned from the bib, docs, and the example `.md`/`.tex` citation lists.

## Housekeeping in the example lists
- Added `nautilus` (a core sampler that was missing from the lists).
- Fixed dangling `dynesty1/2/3` cite keys → `dynesty` + `dynesty4`.
- Fixed the `\textt` → `\texttt` typo and the malformed `numba`/`sqlite` `\href`s in `citations.tex`.

All 35 cite keys used in the example `.md`/`.tex` now resolve against `citations.bib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)