### PR TITLE
docs: fix false 'JAX will also be installed' claim; document [jax] extra

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -144,7 +144,7 @@ from autonerves.fitsable import hdu_list_for_output_from
 
 conf.instance.register(__file__)
 
-__version__ = "2026.7.9.1"
+__version__ = "2026.7.22.1"
 
 from autonerves import check_version
 

--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -144,7 +144,7 @@ from autonerves.fitsable import hdu_list_for_output_from
 
 conf.instance.register(__file__)
 
-__version__ = "2026.7.22.1"
+__version__ = "2026.7.23.1"
 
 from autonerves import check_version
 

--- a/docs/installation/conda.md
+++ b/docs/installation/conda.md
@@ -8,9 +8,17 @@
 
 This acceleration is achieved through \[**JAX**\](<https://docs.jax.dev/en/latest/notebooks/thinking_in_jax.html>), which provides GPU and TPU support.
 
-When you install **PyAutoLens** (see instructions below), JAX will also be installed. However, the default installation may not include GPU support.
+**JAX is not installed by default.** To install **PyAutoLens** with JAX, use the `jax` extra:
 
-To ensure GPU acceleration, it is recommended that you install JAX with GPU support **before** installing **PyAutoLens**, by following the official \[JAX installation guide\](<https://jax.readthedocs.io/en/latest/installation.html>).
+```bash
+pip install autolens[jax] --no-cache-dir
+```
+
+A plain `pip install autolens` gives a fully working install that runs on NumPy, but without any of the JAX
+acceleration described above.
+
+The `[jax]` extra installs **CPU-only** JAX. To ensure GPU acceleration, it is recommended that you install JAX with
+GPU support **before** installing **PyAutoLens**, by following the official \[JAX installation guide\](<https://jax.readthedocs.io/en/latest/installation.html>).
 
 If you install **PyAutoLens** without a proper GPU setup, a warning will be displayed.
 
@@ -49,8 +57,11 @@ The latest version of **PyAutoLens** is installed via pip as follows (the comman
 caching issues impacting the installation):
 
 ```bash
-pip install autolens --no-cache-dir
+pip install autolens[jax] --no-cache-dir
 ```
+
+The `[jax]` extra is recommended, as it enables the JAX acceleration described above. To install without JAX,
+use `pip install autolens --no-cache-dir` instead.
 
 If pip prints warnings about dependency version conflicts, these can usually be ignored — the instructions below
 will identify clearly if the installation is a success.

--- a/docs/installation/pip.md
+++ b/docs/installation/pip.md
@@ -14,9 +14,17 @@ distribution" error. Upgrade Python to 3.12+ before installing.
 
 This acceleration is achieved through \[**JAX**\](<https://docs.jax.dev/en/latest/notebooks/thinking_in_jax.html>), which provides GPU and TPU support.
 
-When you install **PyAutoLens** (see instructions below), JAX will also be installed. However, the default installation may not include GPU support.
+**JAX is not installed by default.** To install **PyAutoLens** with JAX, use the `jax` extra:
 
-To ensure GPU acceleration, it is recommended that you install JAX with GPU support **before** installing **PyAutoLens**, by following the official \[JAX installation guide\](<https://jax.readthedocs.io/en/latest/installation.html>).
+```bash
+pip install autolens[jax]
+```
+
+A plain `pip install autolens` gives a fully working install that runs on NumPy, but without any of the JAX
+acceleration described above.
+
+The `[jax]` extra installs **CPU-only** JAX. To ensure GPU acceleration, it is recommended that you install JAX with
+GPU support **before** installing **PyAutoLens**, by following the official \[JAX installation guide\](<https://jax.readthedocs.io/en/latest/installation.html>).
 
 If you install **PyAutoLens** without a proper GPU setup, a warning will be displayed.
 
@@ -34,6 +42,13 @@ pip install --upgrade pip
 
 The latest version of **PyAutoLens** is installed via pip as follows (specifying the version as shown below ensures
 the installation has clean dependencies):
+
+```bash
+pip install autolens[jax]
+```
+
+The `[jax]` extra is recommended, as it enables the JAX acceleration described above. To install without JAX,
+omit the extra:
 
 ```bash
 pip install autolens


### PR DESCRIPTION
## The bug

`docs/installation/pip.md` and `conda.md` both stated:

> *"When you install **PyAutoLens** (see instructions below), JAX will also be installed."*

**This is false.** `pip install autolens` does not install JAX — it is an optional extra:

```
autolens[jax] -> autogalaxy[jax] -> autonerves[jax] -> jax + jaxlib + jaxnnls
```

A user following the docs exactly gets no JAX and no indication why. Reported from a real install of `2026.7.22.1`.

## Changes

- Replace the false claim with an explicit `pip install autolens[jax]` instruction in both pip and conda docs.
- Note that plain `pip install autolens` is a valid, working NumPy-only install.
- Clarify the `[jax]` extra installs **CPU-only** JAX; GPU still needs the JAX guide first.
- Show `autolens[jax]` as the recommended install command, with the JAX-free variant alongside.
- Sync `__version__` to `2026.7.22.1`.

Not changed: `2026.4.5.3` (historical — the release that dropped Python 3.9–3.11) and `2025.10.6.1` (legacy pin example).