### PR TITLE
docs: registration is the caller's job — correct stale auto-call claims in autolens/jax

### DIFF
--- a/autolens/jax/registration.py
+++ b/autolens/jax/registration.py
@@ -7,10 +7,16 @@ and unflatten across the JIT boundary.
 
 This module is the counterpart of ``AnalysisImaging._register_fit_imaging_pytrees``
 for code paths that do not go through ``Analysis`` (point-source solving,
-custom forward models, hand-built simulators). It is called automatically
-by ``PointSolver(use_jax=True).solve(tracer, ...)`` on the first invocation
-and by ``Simulator(use_jax=True).via_tracer_from(tracer, ...)`` in PyAutoLens
-once Phase 2 ships the Simulator changes.
+custom forward models, hand-built simulators).
+
+**Calling it is the user's responsibility.** Nothing in the library calls it
+for you, and nothing can: JAX flattens a jitted function's arguments at trace
+time, i.e. *before* entering the callee, so a ``solve()`` or
+``via_tracer_from()`` that registered internally would already be too late.
+``PointSolver.solve_triangles`` carries the same note at its own call site.
+Register once, before the first ``@jax.jit`` invocation.
+
+The autogalaxy counterpart is ``autogalaxy.jax.register_galaxies_classes``.
 
 Mirrors PyAutoFit's ``autofit/jax/pytrees.py`` layout. Idempotent: re-registration
 of a class is a silent no-op.


### PR DESCRIPTION
## Summary

The `autolens/jax/registration.py` module docstring claims
`register_tracer_classes` "is called automatically by
`PointSolver(use_jax=True).solve(tracer, ...)` on the first invocation and by
`Simulator(use_jax=True).via_tracer_from(tracer, ...)` in PyAutoLens once Phase 2
ships the Simulator changes."

**Neither is true.** `grep -rn register_tracer_classes autolens/` finds only the
definition and the re-export — nothing in the library calls it. And it *cannot*
be called automatically: `PointSolver.solve_triangles` already carries the reason
at its own call site (`autolens/point/solver/point_solver.py:102-109`):

> Auto-registering inside `solve()` doesn't help because JAX flattens function
> arguments at trace time — before entering this method — so registration must
> run before the first jitted call.

So the docstring promises behaviour that is not merely unshipped but
unimplementable as worded, and it sends readers looking for automatic
registration that will never arrive.

This corrects the docstring to state that calling it is the user's
responsibility, gives the trace-time reason, and cross-references the new
autogalaxy counterpart `autogalaxy.jax.register_galaxies_classes` (added in
PyAutoGalaxy#537).

**Docstring only — zero behaviour change, zero API surface.**

## Context

Found while correcting the same false claim where it had propagated into the
workspaces: both `scripts/guides/using_jax.py` files and the `__JAX Variant__`
sections of several `simulator.py` scripts assert "the simulator handles pytree
registration internally". Those are fixed in the companion workspace PRs;
tracking issue PyAutoLabs/autolens_workspace#379.

Separately, the jitted simulator path fails *even with* correct registration, on
un-threaded `xp` sites in autoarray — that is a real library bug, filed
separately, and not addressed here.

## Test Plan

- [x] `python -m pytest test_autolens/` — **488 passed**, 0 failed
- [x] Verified by grep that no caller exists, so the removed claim describes nothing real

Generated by the PyAutoLabs agent workflow.
