### PR TITLE
docs: point multi-dataset example links at the renamed `multi_dataset` package

### DIFF
--- a/docs/general/model_cookbook.md
+++ b/docs/general/model_cookbook.md
@@ -436,7 +436,7 @@ but certain parameters are free to vary across the datasets.
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/multi/start_here.ipynb>
+<https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/multi_dataset/start_here.ipynb>
 
 ## Relations (Advanced)
 
@@ -445,7 +445,7 @@ We can compose models where the free parameter(s) vary according to a user-speci
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/multi/features/wavelength_dependence/modeling.ipynb>
+<https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/multi_dataset/features/wavelength_dependence/modeling.ipynb>
 
 ## PyAutoFit API
 

--- a/docs/overview/overview_3_features.md
+++ b/docs/overview/overview_3_features.md
@@ -166,7 +166,7 @@ The appearance of the strong changes as a function of wavelength, therefore mult
 more about the different components in a galaxy (e.g a redder bulge and bluer disk) or when imaging and interferometer
 data are combined, we can compare the emission from stars and dust.
 
-Checkout the `autolens_workspace/*/multi` package to get started, however combining datasets is a more advanced
+Checkout the `autolens_workspace/*/multi_dataset` package to get started, however combining datasets is a more advanced
 feature and it is recommended you first get to grips with the core API.
 
 ### Ellipse Fitting


### PR DESCRIPTION
Phase 3 of the `multi` → `multi_dataset` example-package rename (PyAutoLabs/autolens_workspace#408).

Docs-only — **no library source touched**.

## ⚠️ Merge order

**This must merge _after_ the workspace rename PR** (autolens_workspace#414 / autogalaxy_workspace#194). The links updated here are `blob/main` URLs into the workspace; they resolve to the new path only once the package has actually moved on `main`. Merging this first would 404 them.

## What changed

- `docs/general/model_cookbook.md` — GitHub `blob/main` links into the multi-dataset examples.
- `docs/overview/overview_3_features.md` — the `*/multi` package pointer in prose.

## Deliberately NOT changed

`bound: multi` in `config/non_linear.yaml` (and the `test_*/config/` copies) is a **Dynesty search kwarg**, unrelated to this package. A blind `s/multi/multi_dataset/` would have silently corrupted the sampler configuration.

Refs PyAutoLabs/autolens_workspace#408
