### PR TITLE
docs: signpost autolens_assistant from llms.txt

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -5,6 +5,7 @@
 ## Use it (examples & tutorials)
 
 - [autolens_workspace navigator](https://github.com/PyAutoLabs/autolens_workspace/blob/main/llms.txt): end-to-end example scripts and notebooks per science case — the paste-friendly task router. Send any "how do I model / simulate / analyse X?" question here.
+- [autolens_assistant](https://github.com/PyAutoLabs/autolens_assistant): the PyAutoLens AI assistant — task skills, curated API reference, and a science wiki in one repo you drive by conversation (browser chat via a GitHub connector, or a local coding agent); start from its `llms.txt` front door.
 - [HowToLens](https://github.com/PyAutoLabs/HowToLens): from-first-principles lecture series for beginners new to gravitational lensing.
 
 ## API reference & docs


### PR DESCRIPTION
## Summary
The library's llms.txt front door routed to the workspace navigator, HowToLens and RTD, but never named the autolens_assistant — a chat landing on the library repo couldn't discover it. One line under 'Use it', ahead of the assistant paper release.

Part of the llms.txt census (PyAutoLabs/autolens_workspace#451).

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGPARVAg5oUT7rWRDMTA4E