### PR TITLE
fix: stamp source builds above every intra-family dep floor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
 import os
 from setuptools import setup
 
-version = os.environ.get("VERSION", "1.0.dev0")
+# Source builds stamp a version ABOVE every date release. Intra-family deps
+# carry `>=` floors, so a low dev stamp (the old "1.0.dev0") makes a local
+# checkout unsatisfiable against its own siblings. Release builds always set
+# VERSION explicitly, so this default is never published.
+version = os.environ.get("VERSION", "9999.0.0.dev0")
 
 setup(
     version=version,


### PR DESCRIPTION
Part of the fix for **PyAutoLabs/PyAutoNerves#146** — main is broken: every
workspace smoke job has died at the install step since 18:08Z on 2026-08-03.

### The defect

`setup.py` fell back to `"1.0.dev0"` whenever `VERSION` is unset — which is what
*any* source install does. `1.0.dev0` sorts **below every date release**, so a
local checkout advertised itself as older than a 2022 wheel.

That was harmless only while nothing in the family constrained a sibling. Once
the `>=2026.7.29.2` floors landed (PyAutoLens#687), `1.0.dev0` could not satisfy
them and pip raised `ResolutionImpossible`.

### Not fallout from the floors

The same defect was already biting, silently. `autolens_workspace_test`,
`autogalaxy_workspace_test` and `autocti_workspace_test` each carry
`pip install --force-reinstall --no-deps ./PyAutoNerves`, commented *"the
`[optional]` re-resolution above can upgrade autonerves to the stale PyPI
release"* — a PyPI wheel quietly shadowing the local build, patched per repo.
The floors converted a **silent** misinstall into a **loud** one, everywhere at
once.

### Why `9999.0.0.dev0`

- Sorts above every date release, so it satisfies present **and** future floors.
- Keeps `.dev`, so nothing ever claims the checkout is a release.
- Not read by the `autonerves` workspace handshake — that reads `__version__`
  (`2026.7.23.1` on main), not pip metadata. No runtime behaviour changes.
- Release builds always `export VERSION` explicitly, so this default is never
  published. PyAutoHands gains a guard that fails the build if `VERSION` is
  empty, belt-and-braces.

### Verified

- `pip install ./PyAutoNerves ./PyAutoFit` on `main` → the exact
  `ResolutionImpossible` seen in CI.
- The same command against these branches, with **no** `VERSION` set → resolves;
  every package installs from source at `9999.0.0.dev0`, no family wheels from
  PyPI. Confirmed for both the autolens chain (5 packages) and the autocti chain.
- End-to-end pre-merge verification: PyAutoLabs/autolens_workspace_test#246.

### Merge order

All six library PRs merge together. The floors stay exactly as they are.